### PR TITLE
Development

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,7 @@ GUIFILES =	$(wildcard gui/*.tcl)
 NODESFILES =	$(wildcard nodes/*.tcl)
 RUNTIMEFILES =	$(wildcard runtime/*.tcl)
 
-VROOT =	$(wildcard scripts/*.sh) 
+VROOT =	$(wildcard scripts/*.sh)
 TOOLS =	$(filter-out $(VROOT), $(wildcard scripts/*))
 
 NODE_ICONS = frswitch.gif hub.gif lanswitch.gif rj45.gif cloud.gif host.gif \
@@ -34,7 +34,7 @@ SMALL_ICONS = $(NODE_ICONS)
 
 TINY_ICONS = $(NODE_ICONS) link.gif select.gif l2.gif l3.gif freeform.gif \
 		oval.gif rectangle.gif text.gif
-		  
+
 ICONS = imunes_icon32.gif imunes_icon16.gif
 
 info:
@@ -96,10 +96,10 @@ install: uninstall
 		cp icons/normal/$${file} $(NORMAL_ICONSDIR); \
 	done ;
 
-	mkdir -p $(SMALL_ICONSDIR)	
+	mkdir -p $(SMALL_ICONSDIR)
 	for file in $(SMALL_ICONS); do \
 		cp icons/small/$${file} $(SMALL_ICONSDIR); \
-	done ;	
+	done ;
 
 	mkdir -p $(TINY_ICONSDIR)
 	for file in $(TINY_ICONS); do \
@@ -148,14 +148,14 @@ tarball:
 	for file in $(SMALL_ICONS); do \
 		cp icons/small/$${file} ../$(TARBALL_DIR)/icons/small; \
 	done ;
-	
+
 	mkdir -p ../$(TARBALL_DIR)/icons/tiny
 	for file in $(TINY_ICONS); do \
 		cp icons/tiny/$${file} ../$(TARBALL_DIR)/icons/tiny; \
 	done ;
 
 	cd .. && tar czfv $(TARBALL_DIR).tar.gz $(TARBALL_DIR)
-	rm -r ../$(TARBALL_DIR) 
+	rm -r ../$(TARBALL_DIR)
 
 release:
 	rm -f ../$(RELEASE_DIR).tar.gz
@@ -177,11 +177,11 @@ release:
 	for file in $(SMALL_ICONS); do \
 		cp icons/small/$${file} ../$(RELEASE_DIR)/icons/small; \
 	done ;
-	
+
 	mkdir -p ../$(RELEASE_DIR)/icons/tiny
 	for file in $(TINY_ICONS); do \
 		cp icons/tiny/$${file} ../$(RELEASE_DIR)/icons/tiny; \
 	done ;
 
 	cd .. && tar czfv $(RELEASE_DIR).tar.gz $(RELEASE_DIR)
-	rm -r ../$(RELEASE_DIR) 
+	rm -r ../$(RELEASE_DIR)

--- a/README
+++ b/README
@@ -12,9 +12,9 @@ execution engine itself operates within the operating system kernel.
 
 System requirements
 ===================
-  
+
     1) Operating system
- 
+
     IMUNES works on top of the FreeBSD 8 (or higher) kernel that is
     compiled with the VIMAGE option included. A sample kernel kernel
     config file is as follows:
@@ -34,9 +34,9 @@ System requirements
 	$ make depend; make
 	$ make install
 	$ reboot
-  
-    2) FreeBSD packages 
-  
+
+    2) FreeBSD packages
+
     The following packages have to be installed for IMUNES to work:
         tcl86.tbz
         tk86.tbz

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ execution engine itself operates within the operating system kernel.
 System requirements
 -------------------
 
-### Operating system
+### Operating system (FreeBSD)
 
-IMUNES works on top of the FreeBSD 8 (or higher) kernel that is
-compiled with the VIMAGE option included. A sample kernel kernel
-config file is as follows:
+When IMUNES is used on top of FreeBSD 8 (or higher) it requires a kernel
+that is compiled with the VIMAGE option included. A sample kernel config file
+is as follows:
 
     include GENERIC
     nooptions FLOWTABLE
@@ -21,7 +21,7 @@ config file is as follows:
     options VNET_DEBUG
     options KDB
     options DDB
-    
+
     options IPSEC
     device  crypto
     options IPSEC_DEBUG
@@ -42,20 +42,53 @@ Then you need to compile and install the kernel and reboot.
     # make install
     # reboot
 
+### Operating system (Linux)
+
+When IMUNES is used on top of Linux a 3.10 Linux kernel is the
+minimum requirement.
+
 ### FreeBSD packages
 
 First we need to install the packages required for IMUNES. To do
 this execute the following command (on FreeBSD 10.1):
 
     # pkg install tk86 ImageMagick tcllib wireshark socat git gmake
-    
+
+### Linux packages
+
+First we need to install the packages required for IMUNES:
+
+    tcl (version 8.6 or greater)
+    tk (version 8.6 or greater)
+    tcllib
+    wireshark (with GUI)
+    ImageMagick
+    Docker
+    OpenvSwitch
+    xterm
+
+#### Fedora 21
+    # yum install openvswitch docker-io xterm wireshark-gnome ImageMagick tcl tcllib tk
+
+#### Performance
+
+For best performance please run Docker with either Aufs or Overlay storage
+driver. Depending on your kernel version and distribution, Docker will
+automatically select its storage driver based on what is available and what
+the particular default setup for your distribution is. Aufs is not part of
+vanilla kernel but some distributions package it in their modified kernel and
+Overlay is only available from kernel version 3.18. Worst case scenario:
+Docker will use the *extremely* slow devicemapper available everywhere.
+Please view either Docker or distro docs on how to set this up for your
+particular Linux distribution.
+
 ### Installing IMUNES
 
 Checkout the last fresh IMUNES source through the public github
 repository:
 
     # git clone https://github.com/imunes/imunes.git
-    
+
 Now we need to install IMUNES and populate the virtual file system
 with predefined and required data. To install imunes on the system
 execute (as root):
@@ -70,13 +103,11 @@ This is done by issuing the following command (as root):
 
     # imunes -p
 
-The filesystem is by default created in /var/imunes/vroot.
-
 Now the IMUNES GUI can be ran just by typing the imunes command
 in the terminal:
 
     # imunes
-    
+
 To execute experiments, run it as root.
 
 For additional information visit our web site:

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -180,7 +180,7 @@ proc spawnShell { node cmd } {
     # FIXME make this modular
     nexec xterm -sb -rightbar \
     -T "IMUNES: [getNodeName $node] (console) [string trim [lindex [split $cmd /] end] ']" \
-    -e "docker exec -it $node_id $cmd" &
+    -e "docker exec -it $node_id $cmd" 2> /dev/null &
 }
 
 #****f* linux.tcl/fetchRunningExperiments

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -1,4 +1,4 @@
-set VROOT_MASTER "imunes/vroot:base"
+set VROOT_MASTER "docker.io/imunes/vroot:base"
 
 #****f* linux.tcl/writeDataToNodeFile
 # NAME

--- a/scripts/prepare_vroot.sh
+++ b/scripts/prepare_vroot.sh
@@ -2,7 +2,15 @@
 
 ROOTDIR="."
 LIBDIR=""
+DOCKER_TEMPLATE="docker.io/imunes/vroot:base"
 
 VER=`uname -r | cut -d "." -f 1`
+OS=`uname -o`
 
-sh $ROOTDIR/$LIBDIR/scripts/prepare_vroot_$VER\.sh $*
+if [ "$OS" == "GNU/Linux" ]
+then
+    docker pull $DOCKER_TEMPLATE
+else
+    sh $ROOTDIR/$LIBDIR/scripts/prepare_vroot_$VER\.sh $*
+fi
+


### PR DESCRIPTION
readme modifications to include linux
imunes -p on linux
docker.io as default registry -> some users could change this and then imunes/vroot:base wouldn't be available
