### PR TITLE
Added minumum required Docker version to docs:

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ First we need to install the packages required for IMUNES:
     tcllib
     wireshark (with GUI)
     ImageMagick
-    Docker
+    Docker (version 1.4 or greater)
     OpenvSwitch
     xterm
 


### PR DESCRIPTION
1.4.0 (2014-12-11)
New Overlayfs Storage Driver

1.3.0 (2014-10-14)
Docker exec allows you to run additional processes inside existing containers

1.2.0 (2014-08-20)
--cap-add and --cap-drop to tweak what linux capability you want