### PR TITLE
Experiment start time decrease

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ First we need to install the packages required for IMUNES:
     ImageMagick
     Docker (version 1.4 or greater)
     OpenvSwitch
-    nsenter
+    nsenter (part of the util-linux package 2.23+)
     xterm
 
 Note: on some distributions the netem module `sch_netem` required for link configuration is only available by installing additional kernel packages. Please check the availability of the module:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ First we need to install the packages required for IMUNES:
     ImageMagick
     Docker (version 1.4 or greater)
     OpenvSwitch
-    nsenter (part of the util-linux package 2.23+)
+    nsenter (part of the util-linux package since version 2.23 and later)
     xterm
 
 Note: on some distributions the netem module `sch_netem` required for link configuration is only available by installing additional kernel packages. Please check the availability of the module:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ First we need to install the packages required for IMUNES:
     ImageMagick
     Docker (version 1.4 or greater)
     OpenvSwitch
+    nsenter
     xterm
 
 Note: on some distributions the netem module `sch_netem` required for link configuration is only available by installing additional kernel packages. Please check the availability of the module:
@@ -72,10 +73,10 @@ Note: on some distributions the netem module `sch_netem` required for link confi
     # modinfo sch_netem
 
 #### Fedora 22
-    # yum install openvswitch docker-io xterm wireshark-gnome ImageMagick tcl tcllib tk kernel-modules-extra
+    # yum install openvswitch docker-io xterm wireshark-gnome ImageMagick tcl tcllib tk kernel-modules-extra util-linux
 
 #### Debian 8
-    # apt-get install openvswitch-switch docker.io xterm wireshark ImageMagick tcl tcllib tk user-mode-linux
+    # apt-get install openvswitch-switch docker.io xterm wireshark ImageMagick tcl tcllib tk user-mode-linux util-linux
 
 #### Performance
 

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -817,12 +817,17 @@ proc checkSysPrerequisites {} {
         set msg "Cannot start experiment. Is ovs-vswitchd installed and running?\n"
     }
 
+    if { [catch {exec nsenter --version}] } {
+        set msg "Cannot start experiment. Is nsenter installed?\n"
+    }
+
     if { [catch {exec xterm -version}] } {
         set msg "Cannot start experiment. Is xterm installed?\n"
     }
 
     if { $msg != "" } {
-        return "$msg\IMUNES needs docker and ovs-vswitchd services running and xterm installed."
+        return "$msg\IMUNES needs docker and ovs-vswitchd services running and\
+xterm and nsenter installed."
     }
 
     return ""

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -492,8 +492,8 @@ proc runConfOnNode { node } {
     set node_dir [getVrootDir]/$eid/$node
     set node_id "$eid.$node"
 
-    catch {exec docker exec $node_id umount /etc/resolv.conf}
-    catch {exec docker exec $node_id umount /etc/hosts}
+    set nodeNs [getNodeNamespace $node]
+    exec nsenter -m -u -n -i -p -t $nodeNs umount /etc/resolv.conf /etc/hosts
 
     if { [getCustomEnabled $node] == true } {
         set selected [getCustomConfigSelected $node]

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -214,22 +214,22 @@ proc allSnapshotsAvailable {} {
     catch {exec docker images} images
 
     if {"imunes/vroot" in $images} {
-	return 1
+        return 1
     } else {
-	if {$execMode == "batch"} {
-	    puts "Docker template for virtual nodes:
+        if {$execMode == "batch"} {
+            puts "Docker template for virtual nodes:
     $VROOT_MASTER
 is missing.
 Run 'imunes -p' to pull the template."
-	} else {
-	    tk_dialog .dialog1 "IMUNES error" \
-	    "Docker template for virtual nodes:
+        } else {
+            tk_dialog .dialog1 "IMUNES error" \
+        "Docker template for virtual nodes:
     $VROOT_MASTER
 is missing.
 Run 'imunes -p' to pull the template." \
-	    info 0 Dismiss
-	}
-	return 0
+            info 0 Dismiss
+        }
+        return 0
     }
 }
 
@@ -298,7 +298,7 @@ proc createNodeContainer { node } {
     catch {exec docker run -d --privileged --cap-add=ALL --net='none' -h [getNodeName $node] \
         --name $node_id $VROOT_MASTER } err
     if { $debug } {
-	puts "'exec docker run' ($node_id) caught:\n$err"
+        puts "'exec docker run' ($node_id) caught:\n$err"
     }
 
     set status ""
@@ -813,19 +813,19 @@ proc addNodeIfcToBridge { bridge brifc node ifc mac } {
 proc checkSysPrerequisites {} {
     set msg ""
     if { [catch {exec docker ps } err] } {
-	set msg "Cannot start experiment. Is docker installed and running?\n"
+        set msg "Cannot start experiment. Is docker installed and running?\n"
     }
 
     if { [catch {exec pgrep ovs-vswitchd } err ] } {
-	set msg "Cannot start experiment. Is ovs-vswitchd installed and running?\n"
+        set msg "Cannot start experiment. Is ovs-vswitchd installed and running?\n"
     }
 
     if { [catch {exec xterm -version}] } {
-	set msg "Cannot start experiment. Is xterm installed?\n"
+        set msg "Cannot start experiment. Is xterm installed?\n"
     }
 
     if { $msg != "" } {
-	return "$msg\IMUNES needs docker and ovs-vswitchd services running and xterm installed."
+        return "$msg\IMUNES needs docker and ovs-vswitchd services running and xterm installed."
     }
 
     return ""
@@ -1015,17 +1015,17 @@ proc ipsecFilesToNode { eid node local_cert ipsecret_file } {
     set hostname [getNodeName $node]
 
     if { $local_cert != "" } {
-	set trimmed_local_cert [lindex [split $local_cert /] end]
-	catch {exec hcp $local_cert $hostname@$eid:/etc/ipsec.d/certs/$trimmed_local_cert}
+        set trimmed_local_cert [lindex [split $local_cert /] end]
+        catch {exec hcp $local_cert $hostname@$eid:/etc/ipsec.d/certs/$trimmed_local_cert}
     }
 
     if { $ipsecret_file != "" } {
-	set fileId2 [open /tmp/imunes_$node_id\_ipsec.secrets w]
-	puts $fileId2 "# /etc/ipsec.secrets - strongSwan IPsec secrets file\n"
-	set trimmed_local_key [lindex [split $ipsecret_file /] end]
-	catch {exec hcp $ipsecret_file $hostname@$eid:/etc/ipsec.d/private/$trimmed_local_key}
-	puts $fileId2 ": RSA $trimmed_local_key"
-	close $fileId2
+        set fileId2 [open /tmp/imunes_$node_id\_ipsec.secrets w]
+        puts $fileId2 "# /etc/ipsec.secrets - strongSwan IPsec secrets file\n"
+        set trimmed_local_key [lindex [split $ipsecret_file /] end]
+        catch {exec hcp $ipsecret_file $hostname@$eid:/etc/ipsec.d/private/$trimmed_local_key}
+        puts $fileId2 ": RSA $trimmed_local_key"
+        close $fileId2
     }
 
     catch {exec hcp /tmp/imunes_$node_id\_ipsec.conf $hostname@$eid:/etc/ipsec.conf}

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -492,8 +492,7 @@ proc runConfOnNode { node } {
     set node_dir [getVrootDir]/$eid/$node
     set node_id "$eid.$node"
 
-    set nodeNs [getNodeNamespace $node]
-    exec nsenter -m -u -n -i -p -t $nodeNs umount /etc/resolv.conf /etc/hosts
+    exec docker exec $node_id umount /etc/resolv.conf /etc/hosts
 
     if { [getCustomEnabled $node] == true } {
         set selected [getCustomConfigSelected $node]

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -337,8 +337,9 @@ proc configureICMPoptions { node } {
 
     set node_id "$eid.$node"
 
-    pipesExec "docker exec $node_id sysctl net.ipv4.icmp_echo_ignore_broadcasts=1" "hold"
-    pipesExec "docker exec $node_id sysctl net.ipv4.icmp_ratelimit=0" "hold"
+    set nodeNs [getNodeNamespace $node]
+    pipesExec "nsenter --net=/proc/$nodeNs/ns/net sysctl net.ipv4.icmp_echo_ignore_broadcasts=1" "hold"
+    pipesExec "nsenter --net=/proc/$nodeNs/ns/net sysctl net.ipv4.icmp_ratelimit=0" "hold"
 }
 
 proc createLinkBetween { lnode1 lnode2 ifname1 ifname2 } {
@@ -399,9 +400,9 @@ proc createLinkBetween { lnode1 lnode2 ifname1 ifname2 } {
             setIfcNetNs $lnode1 $hostIfc1 $ifname1
             setIfcNetNs $lnode2 $hostIfc2 $ifname2
             # set mac addresses of node ifcs
-            exec ip netns exec "$lnode1Ns" ip link set dev "$ifname1" \
+            exec nsenter --net=/proc/$lnode1Ns/ns/net ip link set dev "$ifname1" \
                 address "$ether1"
-            exec ip netns exec "$lnode2Ns" ip link set dev "$ifname2" \
+            exec nsenter --net=/proc/$lnode2Ns/ns/net ip link set dev "$ifname2" \
                 address "$ether2"
             # remove nodeNs to avoid `ip netns` catching it
             exec rm -f "/var/run/netns/$lnode1Ns"
@@ -453,16 +454,16 @@ proc configureLinkBetween { lnode1 lnode2 ifname1 ifname2 link } {
 proc startIfcsNode { node } {
     upvar 0 ::cf::[set ::curcfg]::eid eid
 
-    set node_id "$eid.$node"
     set cmds ""
+    set nodeNs [getNodeNamespace $node]
     foreach ifc [allIfcList $node] {
         # FIXME: should also work for loopback
         if {$ifc != "lo0"} {
             set mtu [getIfcMTU $node $ifc]
             if {[getIfcOperState $node $ifc] == "up"} {
-                set cmds "$cmds\n docker exec $node_id ip link set dev $ifc up mtu $mtu"
+                set cmds "$cmds\n nsenter --net=/proc/$nodeNs/ns/net ip link set dev $ifc up mtu $mtu"
             } else {
-                set cmds "$cmds\n docker exec $node_id ip link set dev $ifc mtu $mtu"
+                set cmds "$cmds\n nsenter --net=/proc/$nodeNs/ns/net ip link set dev $ifc mtu $mtu"
             }
         }
     }
@@ -513,11 +514,12 @@ proc runConfOnNode { node } {
     exec docker exec $node_id $bootcmd $confFile >& $node_dir/out.log &
     exec docker exec -i $node_id sh -c "cat > out.log" < $node_dir/out.log
 
+    set nodeNs [getNodeNamespace $node]
     foreach ifc [allIfcList $node] {
         # FIXME: should also work for loopback
         if {$ifc != "lo0"} {
             if {[getIfcOperState $node $ifc] == "down"} {
-                exec docker exec $node_id ip link set dev $ifc down
+                exec nsenter --net=/proc/$nodeNs/ns/net ip link set dev $ifc down
             }
         }
     }
@@ -638,10 +640,11 @@ proc l2node.destroy { eid node } {
 #   * node -- node id
 #****
 proc enableIPforwarding { eid node } {
-    pipesExec "docker exec $eid\.$node sysctl net.ipv6.conf.all.forwarding=1" "hold"
-    pipesExec "docker exec $eid\.$node sysctl net.ipv4.conf.all.forwarding=1" "hold"
-    pipesExec "docker exec $eid\.$node sysctl net.ipv4.conf.default.rp_filter=0" "hold"
-    pipesExec "docker exec $eid\.$node sysctl net.ipv4.conf.all.rp_filter=0" "hold"
+    set nodeNs [getNodeNamespace $node]
+    pipesExec "nsenter --net=/proc/$nodeNs/ns/net sysctl net.ipv6.conf.all.forwarding=1" "hold"
+    pipesExec "nsenter --net=/proc/$nodeNs/ns/net sysctl net.ipv4.conf.all.forwarding=1" "hold"
+    pipesExec "nsenter --net=/proc/$nodeNs/ns/net sysctl net.ipv4.conf.default.rp_filter=0" "hold"
+    pipesExec "nsenter --net=/proc/$nodeNs/ns/net sysctl net.ipv4.conf.all.rp_filter=0" "hold"
 }
 
 #****f* linux.tcl/configDefaultLoIfc
@@ -952,42 +955,44 @@ proc execSetLinkParams { eid link } {
     }
 
     if { [[typemodel $lnode1].virtlayer] == "VIMAGE" } {
-        catch {exec docker exec $eid.$lnode1 tc qdisc del dev $ifname1 root}
+        set lnode1Ns [getNodeNamespace $lnode1]
+        catch {exec nsenter --net=/proc/$lnode1Ns/ns/net tc qdisc del dev $ifname1 root}
 
         set vdelay [expr $delay / 1000]
-        exec docker exec $eid.$lnode1 tc qdisc add dev $ifname1 root \
+        exec nsenter --net=/proc/$lnode1Ns/ns/net tc qdisc add dev $ifname1 root \
             handle 1: netem delay ${vdelay}ms
 
-        exec docker exec $eid.$lnode1 tc qdisc add dev $ifname1 parent 1: \
+        exec nsenter --net=/proc/$lnode1Ns/ns/net tc qdisc add dev $ifname1 parent 1: \
             handle 2: netem duplicate ${dup}%
 
         set corrupt [expr (1 / double($ber)) * 100]
-        exec docker exec $eid.$lnode1 tc qdisc add dev $ifname1 parent 2: \
+        exec nsenter --net=/proc/$lnode1Ns/ns/net tc qdisc add dev $ifname1 parent 2: \
             handle 3: netem corrupt ${corrupt}%
 
         if {$bandwidth > 0} {
-            exec docker exec $eid.$lnode1 tc qdisc add dev $ifname1 parent 3: \
+            exec nsenter --net=/proc/$lnode1Ns/ns/net tc qdisc add dev $ifname1 parent 3: \
                 handle 4: tbf rate ${bandwidth}bit limit 10mb burst 1540
         }
 
     }
 
     if { [[typemodel $lnode2].virtlayer] == "VIMAGE" } {
-        catch {exec docker exec $eid.$lnode2 tc qdisc del dev $ifname2 root}
+        set lnode2Ns [getNodeNamespace $lnode2]
+        catch {exec nsenter --net=/proc/$lnode2Ns/ns/net tc qdisc del dev $ifname2 root}
 
         set vdelay [expr $delay / 1000]
-        exec docker exec $eid.$lnode2 tc qdisc add dev $ifname2 root \
+        exec nsenter --net=/proc/$lnode2Ns/ns/net tc qdisc add dev $ifname2 root \
             handle 1: netem delay ${vdelay}ms
 
-        exec docker exec $eid.$lnode2 tc qdisc add dev $ifname2 parent 1: \
+        exec nsenter --net=/proc/$lnode2Ns/ns/net tc qdisc add dev $ifname2 parent 1: \
             handle 2: netem duplicate ${dup}%
 
         set corrupt [expr (1 / double($ber)) * 100]
-        exec docker exec $eid.$lnode2 tc qdisc add dev $ifname2 parent 2: \
+        exec nsenter --net=/proc/$lnode2Ns/ns/net tc qdisc add dev $ifname2 parent 2: \
             handle 3: netem corrupt ${corrupt}%
 
         if {$bandwidth > 0} {
-            exec docker exec $eid.$lnode2 tc qdisc add dev $ifname2 parent 3: \
+            exec nsenter --net=/proc/$lnode2Ns/ns/net tc qdisc add dev $ifname2 parent 3: \
                 handle 4: tbf rate ${bandwidth}bit limit 10mb burst 1540
         }
     }

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -402,9 +402,9 @@ proc createLinkBetween { lnode1 lnode2 ifname1 ifname2 } {
                 address "$ether1"
             exec nsenter -n -t $lnode2Ns ip link set dev "$ifname2" \
                 address "$ether2"
-            # remove nodeNs to avoid `ip netns` catching it
-            exec rm -f "/var/run/netns/$lnode1Ns"
-            exec rm -f "/var/run/netns/$lnode2Ns"
+            # delete net namespace reference files
+            exec ip netns del $lnode1Ns
+            exec ip netns del $lnode2Ns
         }
         if { [[typemodel $lnode2].virtlayer] == "NETGRAPH" } {
             addNodeIfcToBridge $lname2 $ifname2 $lnode1 $ifname1 $ether1
@@ -803,8 +803,8 @@ proc addNodeIfcToBridge { bridge brifc node ifc mac } {
     setIfcNetNs $node $guestIfc $ifc
     # set mac address
     exec nsenter -n -t $nodeNs ip link set dev "$ifc" address "$mac"
-    # remove nodeNs to avoid `ip netns` catching it
-    exec rm -f "/var/run/netns/$nodeNs"
+    # delete net namespace reference file
+    exec ip netns del $nodeNs
 }
 
 proc checkSysPrerequisites {} {


### PR DESCRIPTION
Replacing docker exec with nsenter decreases node configuration (primarily link configuration) time because nsenter is faster. This decreases experiment start time by at least 30% on a Dual Core Intel Pentium B940 @ 2.00GHz with 4GB of RAM

Benchmarking topologies: ../Ping/ping.imn
Number of iterations: 10
Wait time before termination: 5
------------------ Topology: ../Ping/ping.imn ------------------
Topology stats: 11 nodes and 11 links
Average startup time: 6.860 s
Average termination time: 2.941 s
Average memory usage: -5710 KB
(imunes)[cetko@nerevar benchmark]$ sudo ./benchmark.sh -c 10 ../Ping/ping.imn 
Linux 4.0.7-300.fc22.x86_64 #1 SMP Mon Jun 29 22:15:06 UTC 2015 x86_64
Docker version 1.7.0 (API: 1.19, git: 0baf609)
	Storage Driver: overlay
	Backing Filesystem: extfs
Hardware info:
	CPU: Intel(R) Pentium(R) CPU B940 @ 2.00GHz
	Cores: 2
	RAM: 3.77 GB
Benchmarking topologies: ../Ping/ping.imn
Number of iterations: 10
Wait time before termination: 5
------------------ Topology: ../Ping/ping.imn ------------------
Topology stats: 11 nodes and 11 links
Average startup time: 11.295 s
Average termination time: 2.713 s
Average memory usage: 27724 KB


WARNING: This introduces nsenter as requirement. Nsenter is part of the util-linux distribution packages since version 2.23. Some earlier Linux distributions like Ubuntu 14.04 don't have util-linux 2.23 as part of their standard installation. This isn't in contrast to previous requirements because Ubuntu 14.04 doesn't have Docker 1.4. and this is already a requirement so users of that system have to install a newer version of Docker (see #38 and http://askubuntu.com/questions/439056/why-there-is-no-nsenter-in-util-linux). In fact, nsenter could replace docker exec completely but it could be wise to keep it because nsenter can run commands available on the host system inside the container namespace while docker exec uses commands available inside the container. Ubuntu 14.10 and later have nsenter by default. On the other hand, using nsenter basically disables IMUNES to directly run commands on remote Docker containers but this can be handled by checking if node is remote when and if IMUNES gets multihost support.