### PR TITLE
New package name for gnome-themes-standard

### DIFF
--- a/scripts/prepare_vroot_12.sh
+++ b/scripts/prepare_vroot_12.sh
@@ -4,7 +4,7 @@
 
 PACKAGES_MINIMAL="$PACKAGES_MINIMAL bind913"
 PACKAGES="$PACKAGES_MINIMAL $PACKAGES_COMMON isc-dhcp44-server isc-dhcp44-client \
-    sylpheed xorp firefox wireshark gnome-themes-standard"
+    sylpheed xorp firefox wireshark gnome-themes-extra"
 
 checkArgs $*
 


### PR DESCRIPTION
> port moved to x11-themes/gnome-themes-extra on 2018-09-30
REASON: Renamed 

https://www.freshports.org/x11-themes/gnome-themes-standard/