### PR TITLE
Port ImageMagick renamed to ImageMagick6

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then you need to compile and install the kernel and reboot.
 First we need to install the packages required for IMUNES. To do
 this execute the following command (on FreeBSD 9.3 and higher):
 
-    # pkg install tk86 ImageMagick tcllib wireshark socat git gmake
+    # pkg install tk86 ImageMagick6 tcllib wireshark socat git gmake
 
 ## Operating system (Linux)
 


### PR DESCRIPTION
> port moved here from graphics/ImageMagick on 2018-11-10
REASON: Port renamed

https://www.freshports.org/graphics/ImageMagick6/

ImageMagick7 seems like it might work, but not using it per the quote 
from https://svnweb.freebsd.org/ports?view=revision&revision=484640

> Please note that IM7 is not a drop in replacement due to library API 
and command arguments changes.