### PR TITLE
Fish completions

### DIFF
--- a/scripts/hcp.fish
+++ b/scripts/hcp.fish
@@ -1,7 +1,5 @@
 function __fish_hcp_nodes
-	for i in (docker ps | grep imunes | cut -f 1 -d' ')
-		docker inspect $i -f {{.Config.Hostname}}
-	end
+    himage -ln | sed -r 's/.*\((.*)\)/\1/' | tr ' ' '\n'
 end
 
 function __fish_hcp_hosts

--- a/scripts/hcp.fish
+++ b/scripts/hcp.fish
@@ -1,0 +1,16 @@
+function __fish_hcp_nodes
+	for i in (docker ps | grep imunes | cut -f 1 -d' ')
+		docker inspect $i -f {{.Config.Hostname}}
+	end
+end
+
+function __fish_hcp_hosts
+	for i in (__fish_hcp_nodes)
+		printf '%s:\n' $i
+	end
+end
+
+complete -c hcp --arguments '(__fish_hcp_hosts)'
+
+# This does not complete node filesystems correctly, only nodes.
+# We should do something like scp or rsync and use nodes filesystem for completion.

--- a/scripts/himage.fish
+++ b/scripts/himage.fish
@@ -1,7 +1,5 @@
 function __fish_himage_nodes
-	for i in (docker ps | grep imunes | cut -f 1 -d' ')
-		docker inspect $i -f {{.Config.Hostname}}
-	end
+	himage -ln | sed -r 's/.*\((.*)\)/\1/' | tr ' ' '\n'
 end
 
 set -l flags_exclusive   b nt v n e i l ln d

--- a/scripts/himage.fish
+++ b/scripts/himage.fish
@@ -1,0 +1,40 @@
+function __fish_himage_nodes
+	for i in (docker ps | grep imunes | cut -f 1 -d' ')
+		docker inspect $i -f {{.Config.Hostname}}
+	end
+end
+
+set -l flags_exclusive   b nt v n e i l ln d
+set -l flags_no_cmd           v n e i l ln d
+set -l flags_no_host                  l ln d
+
+function __fish_intersperse
+	for i in $argv[2..]
+		printf '%s %s ' $argv[1] $i
+	end
+end
+
+set -l base complete -c himage
+set -l e $base -n "not __fish_seen_argument "(__fish_intersperse --old $flags_exclusive)
+set -l h $base -n "not __fish_seen_argument "(__fish_intersperse --old $flags_no_host)
+set -l c $base -n "not __fish_seen_argument "(__fish_intersperse --old $flags_no_cmd)
+
+$base -f
+
+# Autocomplete old style flags -- only one flag is allowed.
+$e --old b  -d 'run in detached mode (background)'
+$e --old nt -d 'run without pseudo-tty (no-tty)'
+$e --old v  -d 'docker full name (eid.nodename)'
+$e --old n  -d 'docker node name (nodename)'
+$e --old e  -d 'experiment eid name (eid)'
+$e --old i  -d 'docker container id'
+$e --old l  -d 'running experiments eids with experiment data'
+$e --old ln -d 'running experiments eids with node names'
+$e --old d  -d 'dummy flag (used only on FreeBSD)'
+
+# Autocomplete nodes -- only 1 node per command and only autocompleted if there are no flags which do not require them.
+$h -n 'not test (__fish_number_of_cmd_args_wo_opts) -ge 2' --arguments '(__fish_himage_nodes)'
+
+# Autocomplete commands after node -- this assumes that all nodes have the same commands as host.
+# It would be nice if we could somehow use fish installed on nodes to aucomplete commands.
+$c -n 'test (__fish_number_of_cmd_args_wo_opts) -ge 2' -d "Command to run" -xa '(__fish_complete_subcommand --fcs-skip=2)'

--- a/scripts/vlink.fish
+++ b/scripts/vlink.fish
@@ -1,7 +1,5 @@
 function __fish_vlink_links
-	for i in /var/run/imunes/*/links
-		cut -f1 -d' ' $i
-	end
+    vlink -l | sed -r 's/.*\((.*)\)/\1/' | tr ' ' '\n'
 end
 
 set -l flags_exclusive   l s r bw b BER B dly d dup D e eid - help ?

--- a/scripts/vlink.fish
+++ b/scripts/vlink.fish
@@ -1,0 +1,38 @@
+function __fish_vlink_links
+	for i in /var/run/imunes/*/links
+		cut -f1 -d' ' $i
+	end
+end
+
+set -l flags_exclusive   l s r bw b BER B dly d dup D e eid - help ?
+set -l flags_no_link     l                                  - help ?
+
+function __fish_intersperse
+	for i in $argv[2..]
+		printf '%s %s ' $argv[1] $i
+	end
+end
+
+set -l base complete -c vlink
+set -l e $base -n "not __fish_seen_argument "(__fish_intersperse --old $flags_exclusive)
+set -l h $base -n "not __fish_seen_argument "(__fish_intersperse --old $flags_no_link)
+set -l r $e -x
+
+$base -f
+
+# Autocomplete old style flags -- only one flag is allowed.
+$e --old l              -d 'print the list of all links'
+$e --old s              -d 'print link status'
+$e --old r              -d 'set link settings to default values'
+$e --old '-'            -d 'Forcibly stop option processing'
+$e --old '?' --old help -d 'Print this message'
+
+$r -a '(seq 0  1    100)' --old b --old bw  -d 'set link bandwidth (bps) <>'
+$r -a '(seq 0 10   1000)' --old B --old BER -d 'set link BER (1/value) <>'
+$r -a '(seq 0 100 10000)' --old d --old dly -d 'set link delay (us) <>'
+$r -a '(seq 0 1     100)' --old D --old dup -d 'set link duplicate (%) <>'
+
+$r -a '(for i in /var/run/imunes/*; path basename $i; end)' --old e --old eid -d 'specify experiment ID <>'
+
+# Autocomplete links -- only 1 link per command.
+$h -n 'not test (__fish_number_of_cmd_args_wo_opts) -gt 1' --arguments '(__fish_vlink_links)'


### PR DESCRIPTION
Add completions for [fish](https://fishshell.com/) shell.

They have some rough edges as this is my first time writing completions.
Missing features:
- There are no completions for `@eid`
- File completions for `hcp` are incorrect for nodes because we autocomplete based on the host FS
- `vlink` completions assume arguments are passed in with `=` sign, e.g. `-b=15`.
- Number parameters in completions for `vlink` are chosen without much consideration

Notify me if something is missing.
Please test before merging!