### PR TITLE
Update execute.tcl wrong echo

### DIFF
--- a/runtime/execute.tcl
+++ b/runtime/execute.tcl
@@ -657,7 +657,7 @@ proc prepareSystem {} {
     } else {
 	set eid $eid_base
 	while { $eid in $running_eids } {
-	    puts -nonewline "Experiment ID $eid_base already in use, trying "
+	    puts -nonewline "Experiment ID $eid already in use, trying "
 	    set eid [genExperimentId]
 	    puts "$eid."
 	}


### PR DESCRIPTION
The loop that searches for new eids prints out $eid_base every time instead of the (new) $eid

On multiple clashes the output I get is, for example: 
Experiment ID i34b already in use, trying i34c.
Experiment ID i34b already in use, trying i34c.
Experiment ID i34b already in use, trying i34c.
Experiment ID i34b already in use, trying i34b.
Experiment ID i34b already in use, trying i34c.
Experiment ID i34b already in use, trying i34b.
Experiment ID i34b already in use, trying i34c.
