### PR TITLE
Feature: new per-interface menu

### DIFF
--- a/config/ifaces.tcl
+++ b/config/ifaces.tcl
@@ -700,13 +700,8 @@ proc ifcList { node_id } {
     return [getIfacesByType $node_id "phys" "stolen"]
 }
 
-proc ifaceNames { node_id } {
-    set iface_names {}
-    foreach {iface_id iface_cfg} [cfgGet "nodes" $node_id "ifaces"] {
-	lappend iface_names [dictGet $iface_cfg "name"]
-    }
-
-    return $iface_names
+proc ifacesNames { node_id } {
+    return [getIfacesNamesByType $node_id "phys" "stolen"]
 }
 
 proc getIfacesByType { node_id args } {
@@ -726,7 +721,7 @@ proc getIfacesByType { node_id args } {
     return $iface_ids
 }
 
-proc getIfaceNamesByType { node_id args } {
+proc getIfacesNamesByType { node_id args } {
     set filtered_ifaces [getIfacesByType $node_id {*}$args]
 
     set iface_names {}
@@ -753,8 +748,8 @@ proc logIfcList { node_id } {
     return [getIfacesByType $node_id "lo" "vlan"]
 }
 
-proc logIfaceNames { node_id } {
-    return [getIfaceNamesByType $node_id "lo" "vlan"]
+proc logIfacesNames { node_id } {
+    return [getIfacesNamesByType $node_id "lo" "vlan"]
 }
 
 #****f* nodecfg.tcl/isIfcLogical
@@ -792,6 +787,15 @@ proc isIfcLogical { node_id iface_id } {
 #****
 proc allIfcList { node_id } {
     return [dict keys [cfgGet "nodes" $node_id "ifaces"]]
+}
+
+proc allIfacesNames { node_id } {
+    set iface_names {}
+    foreach {iface_id iface_cfg} [cfgGet "nodes" $node_id "ifaces"] {
+	lappend iface_names [dictGet $iface_cfg "name"]
+    }
+
+    return $iface_names
 }
 
 #****f* nodecfg.tcl/logicalPeerByIfc
@@ -1036,13 +1040,13 @@ proc newIface { node_id iface_type auto_config { stolen_iface "" } } {
     switch -exact $iface_type {
 	"lo" -
 	"vlan" {
-	    set iface_name [newObjectId [ifaceNames $node_id] $iface_type]
+	    set iface_name [newObjectId [allIfacesNames $node_id] $iface_type]
 	}
 	"phys" {
-	    set iface_name [newObjectId [ifaceNames $node_id] [[getNodeType $node_id].ifacePrefix]]
+	    set iface_name [newObjectId [allIfacesNames $node_id] [[getNodeType $node_id].ifacePrefix]]
 	}
 	"stolen" {
-	    if { $stolen_iface != "UNASSIGNED" && $stolen_iface in [ifaceNames $node_id] } {
+	    if { $stolen_iface != "UNASSIGNED" && $stolen_iface in [allIfacesNames $node_id] } {
 		return ""
 	    }
 

--- a/gui/ifacesGUI.tcl
+++ b/gui/ifacesGUI.tcl
@@ -584,13 +584,8 @@ proc _ifcList { node_cfg } {
     return [_getIfacesByType $node_cfg "phys" "stolen"]
 }
 
-proc _ifaceNames { node_cfg } {
-    set iface_names {}
-    foreach {iface_id iface_cfg} [_cfgGet $node_cfg "ifaces"] {
-	lappend iface_names [_cfgGet $iface_cfg "name"]
-    }
-
-    return $iface_names
+proc _ifacesNames { node_cfg } {
+    return [_getIfacesNamesByType $node_cfg "phys" "stolen"]
 }
 
 proc _getIfacesByType { node_cfg args } {
@@ -610,7 +605,7 @@ proc _getIfacesByType { node_cfg args } {
     return $iface_ids
 }
 
-proc _getIfaceNamesByType { node_cfg args } {
+proc _getIfacesNamesByType { node_cfg args } {
     set filtered_ifaces [_getIfacesByType $node_cfg {*}$args]
 
     set iface_names {}
@@ -637,8 +632,8 @@ proc _logIfcList { node_cfg } {
     return [_getIfacesByType $node_cfg "lo" "vlan"]
 }
 
-proc _logIfaceNames { node_cfg } {
-    return [_getIfaceNamesByType $node_cfg "lo" "vlan"]
+proc _logIfacesNames { node_cfg } {
+    return [_getIfacesNamesByType $node_cfg "lo" "vlan"]
 }
 
 #****f* nodecfg.tcl/isIfcLogical
@@ -678,6 +673,15 @@ proc _allIfcList { node_cfg } {
     return [dict keys [_cfgGet $node_cfg "ifaces"]]
 }
 
+proc _allIfacesNames { node_cfg } {
+    set iface_names {}
+    foreach {iface_id iface_cfg} [_cfgGet $node_cfg "ifaces"] {
+	lappend iface_names [_cfgGet $iface_cfg "name"]
+    }
+
+    return $iface_names
+}
+
 proc _ifaceIdFromName { node_cfg iface_name } {
     foreach {iface_id iface_cfg} [_cfgGet $node_cfg "ifaces"] {
 	if { $iface_name == [_cfgGet $iface_cfg "name"] } {
@@ -710,13 +714,13 @@ proc _newIface { node_cfg iface_type auto_config { stolen_iface "" } } {
     switch -exact $iface_type {
 	"lo" -
 	"vlan" {
-	    set iface_name [newObjectId [_ifaceNames $node_cfg] $iface_type]
+	    set iface_name [newObjectId [_allIfacesNames $node_cfg] $iface_type]
 	}
 	"phys" {
-	    set iface_name [newObjectId [_ifaceNames $node_cfg] [[dictGet $node_cfg "type"].ifacePrefix]]
+	    set iface_name [newObjectId [_allIfacesNames $node_cfg] [[dictGet $node_cfg "type"].ifacePrefix]]
 	}
 	"stolen" {
-	    if { $stolen_iface != "UNASSIGNED" && $stolen_iface in [_ifaceNames $node_cfg] } {
+	    if { $stolen_iface != "UNASSIGNED" && $stolen_iface in [_allIfacesNames $node_cfg] } {
 		return [list "" $node_cfg]
 	    }
 

--- a/gui/initgui.tcl
+++ b/gui/initgui.tcl
@@ -1184,6 +1184,7 @@ menu .button3menu.canvases -tearoff 0
 menu .button3menu.icon -tearoff 0
 menu .button3menu.transform -tearoff 0
 menu .button3menu.sett -tearoff 0
+menu .button3menu.iface_settings -tearoff 0
 menu .button3menu.services -tearoff 0
 menu .button3menu.node_execute -tearoff 0
 menu .button3menu.node_config -tearoff 0

--- a/gui/nodecfgGUI.tcl
+++ b/gui/nodecfgGUI.tcl
@@ -202,7 +202,7 @@ proc configGUI_addTree { wi node_id } {
 
     set sorted_iface_list {}
     set sorted_logiface_list {}
-    foreach iface_name [lsort -ascii [_ifaceNames $node_cfg]] {
+    foreach iface_name [lsort -ascii [_allIfacesNames $node_cfg]] {
 	set iface_id [_ifaceIdFromName $node_cfg $iface_name]
 	if { $iface_id in $iface_list } {
 	    lappend sorted_iface_list $iface_id
@@ -534,7 +534,7 @@ proc configGUI_refreshIfcsTree { wi node_id } {
 
     set sorted_iface_list {}
     set sorted_logiface_list {}
-    foreach iface_name [lsort -ascii [_ifaceNames $node_cfg]] {
+    foreach iface_name [lsort -ascii [_allIfacesNames $node_cfg]] {
 	set iface_id [_ifaceIdFromName $node_cfg $iface_name]
 	if { $iface_id in $iface_list } {
 	    lappend sorted_iface_list $iface_id
@@ -839,7 +839,7 @@ proc configGUI_logicalInterfaces { wi node_id iface_id } {
     ttk::frame $wi.if$iface_id -relief groove -borderwidth 2 -padding 4
     ttk::label $wi.if$iface_id.txt -text "Manage logical interfaces:"
 
-    set logifaces_list [lsort [_logIfaceNames $curnode]]
+    set logifaces_list [lsort [_logIfacesNames $curnode]]
     listbox $wi.if$iface_id.list -height 7 -width 10 -listvariable logifaces_list
 
     ttk::label $wi.if$iface_id.addtxt -text "Add new interface:"
@@ -866,7 +866,7 @@ proc configGUI_logicalInterfaces { wi node_id iface_id } {
 	    return
 	}
 
-	set logifaces_list [lsort [_logIfaceNames $curnode]]
+	set logifaces_list [lsort [_logIfacesNames $curnode]]
 	$wi.rmvbox configure -values $logifaces_list
 	$wi.list configure -listvariable logifaces_list
 
@@ -904,7 +904,7 @@ proc configGUI_logicalInterfaces { wi node_id iface_id } {
 	$wi.rmvbox set ""
 	set node_cfg [_removeIface $node_cfg $iface_id]
 
-	set logifaces_list [lsort [_logIfaceNames $curnode]]
+	set logifaces_list [lsort [_logIfacesNames $curnode]]
 	$wi.rmvbox configure -values $logifaces_list
 	$wi.list configure -listvariable logifaces_list
 
@@ -953,7 +953,7 @@ proc configGUI_physicalInterfaces { wi node_id iface_id } {
     ttk::frame $wi.if$iface_id -relief groove -borderwidth 2 -padding 4
     ttk::label $wi.if$iface_id.txt -text "Manage physical interfaces:"
 
-    set ifaces_list [lsort [_ifaceNames $node_cfg]]
+    set ifaces_list [lsort [_allIfacesNames $node_cfg]]
     listbox $wi.if$iface_id.list -height 7 -width 10 -listvariable ifaces_list
 
     ttk::label $wi.if$iface_id.addtxt -text "Add new interface:"
@@ -990,7 +990,7 @@ proc configGUI_physicalInterfaces { wi node_id iface_id } {
 	    return
 	}
 
-	set ifaces_list [lsort [_ifaceNames $node_cfg]]
+	set ifaces_list [lsort [_allIfacesNames $node_cfg]]
 	$wi.rmvbox configure -values $ifaces_list
 	$wi.list configure -listvariable ifaces_list
 
@@ -1041,7 +1041,7 @@ proc configGUI_physicalInterfaces { wi node_id iface_id } {
 	$wi.rmvbox set ""
 	set node_cfg [_removeIface $node_cfg $iface_id]
 
-	set ifaces_list [lsort [_ifaceNames $curnode]]
+	set ifaces_list [lsort [_allIfacesNames $curnode]]
 	$wi.rmvbox configure -values $ifaces_list
 	$wi.list configure -listvariable ifaces_list
 
@@ -2292,7 +2292,7 @@ proc configGUI_ifcVlanConfig { wi node_id iface_id } {
     ttk::label $wi.if$iface_id.vlancfg.devtxt -text "Vlan dev" -anchor w
     ttk::combobox $wi.if$iface_id.vlancfg.dev -width 6 -textvariable ifvdev$iface_id
     $wi.if$iface_id.vlancfg.dev configure -state readonly -values \
-	[removeFromList [_ifaceNames $node_cfg] [_getIfcName $node_cfg $iface_id]]
+	[removeFromList [_allIfacesNames $node_cfg] [_getIfcName $node_cfg $iface_id]]
 
     pack $wi.if$iface_id.vlancfg -anchor w -padx 10
     grid $wi.if$iface_id.vlancfg.devtxt -in $wi.if$iface_id.vlancfg -column 0 -row 0 \
@@ -6471,7 +6471,7 @@ proc configGUI_ifcRuleConfigApply { add dup } {
 
     switch -regexp $action {
 	(no)?match_hook {
-	    set vals [removeFromList [lsort [_ifaceNames $node_cfg]] $iface_name]
+	    set vals [removeFromList [lsort [_allIfacesNames $node_cfg]] $iface_name]
 	    if { $action_data ni $vals } {
 		tk_dialog .dialog1 "IMUNES warning" \
 		    "ActData: Select one of the existing hooks, but not the current one ($iface_name)." \
@@ -6481,7 +6481,7 @@ proc configGUI_ifcRuleConfigApply { add dup } {
 	    }
 	}
 	(no)?match_dupto {
-	    set vals [removeFromList [lsort [_ifaceNames $node_cfg]] $iface_name]
+	    set vals [removeFromList [lsort [_allIfacesNames $node_cfg]] $iface_name]
 	    if { $action_data ni $vals } {
 		tk_dialog .dialog1 "IMUNES warning" \
 		    "ActData: Select one of the existing hooks, but not the current one ($iface_name)." \
@@ -6628,13 +6628,13 @@ proc refreshIfcActionDataValues { node_id refresh } {
     global ifcFilterAction$iface_id$rule ifcFilterActionData$iface_id$rule
     switch -regexp [set ifcFilterAction$iface_id$rule] {
 	(no)?match_hook {
-	    set vals [removeFromList [lsort [_ifaceNames $node_cfg]] [_getIfcName $node_cfg $iface_id]]
+	    set vals [removeFromList [lsort [_allIfacesNames $node_cfg]] [_getIfcName $node_cfg $iface_id]]
 	    if { [set ifcFilterActionData$iface_id$rule] == "" || $refresh == 1 } {
 		set ifcFilterActionData$iface_id$rule [lindex $vals 0]
 	    }
 	}
 	(no)?match_dupto {
-	    set vals [removeFromList [lsort [_ifaceNames $node_cfg]] [_getIfcName $node_cfg $iface_id]]
+	    set vals [removeFromList [lsort [_allIfacesNames $node_cfg]] [_getIfcName $node_cfg $iface_id]]
 	    if { [set ifcFilterActionData$iface_id$rule] == "" || $refresh == 1 } {
 		set ifcFilterActionData$iface_id$rule [lindex $vals 0]
 	    }

--- a/runtime/cfgparse.tcl
+++ b/runtime/cfgparse.tcl
@@ -1005,7 +1005,7 @@ proc loadCfgLegacy { cfg } {
 	    exit
 	}
 
-	if { $node_type != "extelem" && "lo0" ni [logIfaceNames $node_id] && \
+	if { $node_type != "extelem" && "lo0" ni [logIfacesNames $node_id] && \
 	    [$node_type.netlayer] == "NETWORK" } {
 
 	    set logiface_id [newLogIface $node_id "lo"]

--- a/runtime/freebsd.tcl
+++ b/runtime/freebsd.tcl
@@ -908,7 +908,7 @@ proc fetchNodeRunningConfig { node_id } {
     # overwrite any unsaved changes to this node
     set cur_node_cfg [cfgGet "nodes" $node_id]
 
-    set ifaces_names "[logIfaceNames $node_id] [ifaceNames $node_id]"
+    set ifaces_names [allIfacesNames $node_id]
 
     set iface_id ""
     set loopback 0

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -1674,7 +1674,7 @@ proc fetchNodeRunningConfig { node_id } {
     # overwrite any unsaved changes to this node
     set cur_node_cfg [cfgGet "nodes" $node_id]
 
-    set ifaces_names "[logIfaceNames $node_id] [ifaceNames $node_id]"
+    set ifaces_names [allIfacesNames $node_id]
 
     catch { exec docker exec [getFromRunning "eid"].$node_id sh -c "ip --json a" } json
     foreach elem [json::json2dict $json] {


### PR DESCRIPTION
Add a new right-click menu for NETWORK nodes - `'Interface settings'`.

This enables per-interface operations, such as removing IPv4/IPv6 addresses or matching its IPv4/IPv6 address to other nodes on the same subnet.

Those operations are added to each interface menu as:
`Remove IPv4 addresses`
`Remove IPv6 addresses`
`Match IPv4 subnet`
`Match IPv6 subnet`

There are two more things in this patch: 
 - refactored the `autoIPv*addr` procedures so they prioritize the external interface, routers and nat64 nodes when assigning the new IP addresses,
 -  refactored the `removeIPv*nodes` procedure (and renamed them to `removeIPv*Nodes`) so they receive arguments (lists of nodes and interfaces).