### PR TITLE
Feature: Enable running a DHCP client on interfaces

### DIFF
--- a/config/ifaces.tcl
+++ b/config/ifaces.tcl
@@ -380,7 +380,7 @@ proc setIfcMACaddr { node_id iface_id addr } {
 # NAME
 #   getIfcIPv4addrs -- get interface IPv4 addresses.
 # SYNOPSIS
-#   set addrs [getIfcIPv4addrs $node_id $iface_id]
+#   set addrs4 [getIfcIPv4addrs $node_id $iface_id]
 # FUNCTION
 #   Returns the list of IPv4 addresses assigned to the specified interface.
 # INPUTS
@@ -398,17 +398,17 @@ proc getIfcIPv4addrs { node_id iface_id } {
 # NAME
 #   setIfcIPv4addrs -- set interface IPv4 addresses.
 # SYNOPSIS
-#   setIfcIPv4addrs $node_id $iface_id $addrs
+#   setIfcIPv4addrs $node_id $iface_id $addrs4
 # FUNCTION
 #   Sets new IPv4 address(es) on an interface. The correctness of the IP
 #   address format is not checked / enforced.
 # INPUTS
 #   * node_id -- the node id of the node whose interface's IPv4 address is set.
 #   * iface_id -- interface id
-#   * addrs -- new IPv4 addresses.
+#   * addrs4 -- new IPv4 addresses.
 #****
-proc setIfcIPv4addrs { node_id iface_id addrs } {
-    cfgSet "nodes" $node_id "ifaces" $iface_id "ipv4_addrs" $addrs
+proc setIfcIPv4addrs { node_id iface_id addrs4 } {
+    cfgSet "nodes" $node_id "ifaces" $iface_id "ipv4_addrs" $addrs4
 
     trigger_ifaceReconfig $node_id $iface_id
 
@@ -518,7 +518,7 @@ proc setIfcName { node_id iface_id name } {
 # NAME
 #   getIfcIPv6addrs -- get interface IPv6 addresses.
 # SYNOPSIS
-#   set addrs [getIfcIPv6addrs $node_id $iface_id]
+#   set addrs6 [getIfcIPv6addrs $node_id $iface_id]
 # FUNCTION
 #   Returns the list of IPv6 addresses assigned to the specified interface.
 # INPUTS
@@ -536,17 +536,17 @@ proc getIfcIPv6addrs { node_id iface_id } {
 # NAME
 #   setIfcIPv6addrs -- set interface IPv6 addresses.
 # SYNOPSIS
-#   setIfcIPv6addrs $node_id $iface_id $addrs
+#   setIfcIPv6addrs $node_id $iface_id $addrs6
 # FUNCTION
 #   Sets new IPv6 address(es) on an interface. The correctness of the IP
 #   address format is not checked / enforced.
 # INPUTS
 #   * node_id -- the node id of the node whose interface's IPv6 address is set.
 #   * iface_id -- interface id
-#   * addrs -- new IPv6 addresses.
+#   * addrs6 -- new IPv6 addresses.
 #****
-proc setIfcIPv6addrs { node_id iface_id addrs } {
-    cfgSet "nodes" $node_id "ifaces" $iface_id "ipv6_addrs" $addrs
+proc setIfcIPv6addrs { node_id iface_id addrs6 } {
+    cfgSet "nodes" $node_id "ifaces" $iface_id "ipv6_addrs" $addrs6
 
     trigger_ifaceReconfig $node_id $iface_id
 
@@ -1143,9 +1143,9 @@ proc nodeCfggenIfc { node_id iface_id } {
     }
 
     set primary 1
-    set addrs [getIfcIPv4addrs $node_id $iface_id]
-    setToRunning "${node_id}|${iface_id}_old_ipv4_addrs" $addrs
-    foreach addr $addrs {
+    set addrs4 [getIfcIPv4addrs $node_id $iface_id]
+    setToRunning "${node_id}|${iface_id}_old_ipv4_addrs" $addrs4
+    foreach addr $addrs4 {
 	if { $addr != "" } {
 	    lappend cfg [getIPv4IfcCmd $iface_name $addr $primary]
 	    set primary 0
@@ -1153,13 +1153,13 @@ proc nodeCfggenIfc { node_id iface_id } {
     }
 
     set primary 1
-    set addrs [getIfcIPv6addrs $node_id $iface_id]
-    setToRunning "${node_id}|${iface_id}_old_ipv6_addrs" $addrs
+    set addrs6 [getIfcIPv6addrs $node_id $iface_id]
+    setToRunning "${node_id}|${iface_id}_old_ipv6_addrs" $addrs6
     if { $isOSlinux } {
 	# Linux is prioritizing IPv6 addresses in reversed order
-	set addrs [lreverse $addrs]
+	set addrs6 [lreverse $addrs6]
     }
-    foreach addr $addrs {
+    foreach addr $addrs6 {
 	if { $addr != "" } {
 	    lappend cfg [getIPv6IfcCmd $iface_name $addr $primary]
 	    set primary 0
@@ -1181,16 +1181,16 @@ proc nodeUncfggenIfc { node_id iface_id } {
 
     set iface_name [getIfcName $node_id $iface_id]
 
-    set addrs [getFromRunning "${node_id}|${iface_id}_old_ipv4_addrs"]
-    foreach addr $addrs {
+    set addrs4 [getFromRunning "${node_id}|${iface_id}_old_ipv4_addrs"]
+    foreach addr $addrs4 {
         if { $addr != "" } {
             lappend cfg [getDelIPv4IfcCmd $iface_name $addr]
         }
     }
     unsetRunning "${node_id}|${iface_id}_old_ipv4_addrs"
 
-    set addrs [getFromRunning "${node_id}|${iface_id}_old_ipv6_addrs"]
-    foreach addr $addrs {
+    set addrs4 [getFromRunning "${node_id}|${iface_id}_old_ipv6_addrs"]
+    foreach addr $addrs4 {
         if { $addr != "" } {
             lappend cfg [getDelIPv6IfcCmd $iface_name $addr]
         }
@@ -1231,9 +1231,9 @@ proc routerCfggenIfc { node_id iface_id } {
 	    lappend cfg "conf term"
 	    lappend cfg "interface $iface_name"
 
-	    set addrs [getIfcIPv4addrs $node_id $iface_id]
-	    setToRunning "${node_id}|${iface_id}_old_ipv4_addrs" $addrs
-	    foreach addr $addrs {
+	    set addrs4 [getIfcIPv4addrs $node_id $iface_id]
+	    setToRunning "${node_id}|${iface_id}_old_ipv4_addrs" $addrs4
+	    foreach addr $addrs4 {
 		if { $addr != "" } {
 		    lappend cfg " ip address $addr"
 		}
@@ -1245,9 +1245,9 @@ proc routerCfggenIfc { node_id iface_id } {
 		}
 	    }
 
-	    set addrs [getIfcIPv6addrs $node_id $iface_id]
-	    setToRunning "${node_id}|${iface_id}_old_ipv6_addrs" $addrs
-	    foreach addr $addrs {
+	    set addrs6 [getIfcIPv6addrs $node_id $iface_id]
+	    setToRunning "${node_id}|${iface_id}_old_ipv6_addrs" $addrs6
+	    foreach addr $addrs6 {
 		if { $addr != "" } {
 		    lappend cfg " ipv6 address $addr"
 		}
@@ -1295,8 +1295,8 @@ proc routerUncfggenIfc { node_id iface_id } {
 	    lappend cfg "conf term"
 	    lappend cfg "interface $iface_name"
 
-	    set addrs [getFromRunning "${node_id}|${iface_id}_old_ipv4_addrs"]
-	    foreach addr $addrs {
+	    set addrs4 [getFromRunning "${node_id}|${iface_id}_old_ipv4_addrs"]
+	    foreach addr $addrs4 {
 		if { $addr != "" } {
 		    lappend cfg " no ip address $addr"
 		}
@@ -1308,8 +1308,8 @@ proc routerUncfggenIfc { node_id iface_id } {
 		}
 	    }
 
-	    set addrs [getFromRunning "${node_id}|${iface_id}_old_ipv6_addrs"]
-	    foreach addr $addrs {
+	    set addrs6 [getFromRunning "${node_id}|${iface_id}_old_ipv6_addrs"]
+	    foreach addr $addrs6 {
 		if { $addr != "" } {
 		    lappend cfg " no ipv6 address $addr"
 		}

--- a/config/ifaces.tcl
+++ b/config/ifaces.tcl
@@ -1233,9 +1233,11 @@ proc routerCfggenIfc { node_id iface_id } {
 
 	    set addrs4 [getIfcIPv4addrs $node_id $iface_id]
 	    setToRunning "${node_id}|${iface_id}_old_ipv4_addrs" $addrs4
-	    foreach addr $addrs4 {
-		if { $addr != "" } {
-		    lappend cfg " ip address $addr"
+	    if { $addrs4 != "dhcp" } {
+		foreach addr $addrs4 {
+		    if { $addr != "" } {
+			lappend cfg " ip address $addr"
+		    }
 		}
 	    }
 
@@ -1267,6 +1269,10 @@ proc routerCfggenIfc { node_id iface_id } {
 
 	    lappend cfg "!"
 	    lappend cfg "__EOF__"
+
+	    if { $addrs4 == "dhcp" } {
+		lappend cfg "[getIPv4IfcCmd $iface_name $addrs4 1]"
+	    }
 	}
 	"static" {
 	    set cfg [concat $cfg [nodeCfggenIfc $node_id $iface_id]]
@@ -1296,9 +1302,11 @@ proc routerUncfggenIfc { node_id iface_id } {
 	    lappend cfg "interface $iface_name"
 
 	    set addrs4 [getFromRunning "${node_id}|${iface_id}_old_ipv4_addrs"]
-	    foreach addr $addrs4 {
-		if { $addr != "" } {
-		    lappend cfg " no ip address $addr"
+	    if { $addrs4 != "dhcp" } {
+		foreach addr $addrs4 {
+		    if { $addr != "" } {
+			lappend cfg " no ip address $addr"
+		    }
 		}
 	    }
 
@@ -1325,6 +1333,10 @@ proc routerUncfggenIfc { node_id iface_id } {
 
 	    lappend cfg "!"
 	    lappend cfg "__EOF__"
+
+	    if { $addrs4 == "dhcp" } {
+		lappend cfg "[getDelIPv4IfcCmd $iface_name $addrs4]"
+	    }
 	}
 	"static" {
 	    set cfg [concat $cfg [nodeUncfggenIfc $node_id $iface_id]]

--- a/config/ipv4.tcl
+++ b/config/ipv4.tcl
@@ -499,3 +499,25 @@ proc checkIPv4Nets { str } {
     }
     return 1
 }
+
+#****f* ipv4.tcl/checkIPv4NetsDHCP
+# NAME
+#   checkIPv4NetsDHCP -- check the IPv4 networks (including 'dhcp')
+# SYNOPSIS
+#   set valid [checkIPv4NetsDHCP $str]
+# FUNCTION
+#   Checks if the provided string is a valid IPv4 networks or 'dhcp'.
+# INPUTS
+#   * str -- string to be evaluated. Valid IPv4 networks are writen in form
+#     a.b.c.d; e.f.g.h or a single string: dhcp
+# RESULT
+#   * valid -- function returns 0 if the input string is not in the form
+#     of a valid IP network or 'dhcp', 1 otherwise
+#****
+proc checkIPv4NetsDHCP { str } {
+    if { $str == "dhcp" } {
+	return 1
+    }
+
+    return [checkIPv4Nets $str]
+}

--- a/config/nodecfg.tcl
+++ b/config/nodecfg.tcl
@@ -492,6 +492,9 @@ proc getSubnetData { this_node_id this_iface_id subnet_gws nodes_l2data subnet_i
 	    # this node is a router/extnat, add our IP addresses to lists
 	    # TODO: multiple addresses per iface - split subnet4data and subnet6data
 	    set gw4 [lindex [split [getIfcIPv4addrs $this_node_id $this_iface_id] /] 0]
+	    if { $gw4 == "dhcp" } {
+		set gw4 ""
+	    }
 	    set gw6 [lindex [split [getIfcIPv6addrs $this_node_id $this_iface_id] /] 0]
 	    lappend my_gws $this_type|$gw4|$gw6
 	    lset subnet_gws $subnet_idx $my_gws
@@ -706,6 +709,10 @@ proc getDefaultRoutesConfig { node_id gws } {
 
 	set match4 false
 	foreach ipv4_addr $ipv4_addrs {
+	    if { $ipv4_addr == "dhcp" } {
+		continue
+	    }
+
 	    set mask [ip::mask $ipv4_addr]
 	    if { [ip::prefix $gateway4/$mask] == [ip::prefix $ipv4_addr] } {
 		set match4 true

--- a/gui/nodecfgGUI.tcl
+++ b/gui/nodecfgGUI.tcl
@@ -1617,13 +1617,13 @@ proc configGUI_ifcIPv4Address { wi node_id iface_id } {
     ttk::entry $wi.if$iface_id.ipv4.addr -width 45 \
 	-validate focus -invalidcommand "focusAndFlash %W"
 
-    set addrs ""
+    set addrs4 ""
     foreach addr [_getIfcIPv4addrs $node_cfg $iface_id] {
-	append addrs "$addr" "; "
+	append addrs4 "$addr" "; "
     }
 
-    set addrs [string trim $addrs "; "]
-    $wi.if$iface_id.ipv4.addr insert 0 $addrs
+    set addrs4 [string trim $addrs4 "; "]
+    $wi.if$iface_id.ipv4.addr insert 0 $addrs4
     $wi.if$iface_id.ipv4.addr configure -validatecommand { checkIPv4Nets %P }
 
     pack $wi.if$iface_id.ipv4.txt $wi.if$iface_id.ipv4.addr -side left
@@ -1651,13 +1651,13 @@ proc configGUI_ifcIPv6Address { wi node_id iface_id } {
     ttk::entry $wi.if$iface_id.ipv6.addr -width 45 \
 	-validate focus -invalidcommand "focusAndFlash %W"
 
-    set addrs ""
+    set addrs6 ""
     foreach addr [_getIfcIPv6addrs $node_cfg $iface_id] {
-	append addrs "$addr" "; "
+	append addrs6 "$addr" "; "
     }
 
-    set addrs [string trim $addrs "; "]
-    $wi.if$iface_id.ipv6.addr insert 0 $addrs
+    set addrs6 [string trim $addrs6 "; "]
+    $wi.if$iface_id.ipv6.addr insert 0 $addrs6
     $wi.if$iface_id.ipv6.addr configure -validatecommand { checkIPv6Nets %P }
 
     pack $wi.if$iface_id.ipv6.txt $wi.if$iface_id.ipv6.addr -side left
@@ -2629,17 +2629,17 @@ proc configGUI_ifcMACAddressApply { wi node_id iface_id } {
 proc configGUI_ifcIPv4AddressApply { wi node_id iface_id } {
     global changed force apply node_cfg
 
-    set ipaddrs [formatIPaddrList [$wi.if$iface_id.ipv4.addr get]]
-    foreach ipaddr $ipaddrs {
-	if { [checkIPv4Net $ipaddr] == 0 } {
+    set addrs4 [formatIPaddrList [$wi.if$iface_id.ipv4.addr get]]
+    foreach addr $addrs4 {
+	if { [checkIPv4Net $addr] == 0 } {
 	    return
 	}
     }
 
     set oldipaddrs [_getIfcIPv4addrs $node_cfg $iface_id]
-    if { $force || $ipaddrs != $oldipaddrs } {
+    if { $force || $addrs4 != $oldipaddrs } {
 	if { $apply == 1 } {
-	    set node_cfg [_setIfcIPv4addrs $node_cfg $iface_id $ipaddrs]
+	    set node_cfg [_setIfcIPv4addrs $node_cfg $iface_id $addrs4]
 	}
 	set changed 1
 
@@ -2648,7 +2648,7 @@ proc configGUI_ifcIPv4AddressApply { wi node_id iface_id } {
 	    set node_existing_ipv4 [removeFromList $node_existing_ipv4 $oldipaddrs]
 	}
 
-	lappend node_existing_ipv4 {*}$ipaddrs
+	lappend node_existing_ipv4 {*}$addrs4
     }
 }
 
@@ -2668,17 +2668,17 @@ proc configGUI_ifcIPv4AddressApply { wi node_id iface_id } {
 proc configGUI_ifcIPv6AddressApply { wi node_id iface_id } {
     global changed force apply node_cfg
 
-    set ipaddrs [formatIPaddrList [$wi.if$iface_id.ipv6.addr get]]
-    foreach ipaddr $ipaddrs {
-	if { [checkIPv6Net $ipaddr] == 0 } {
+    set addrs6 [formatIPaddrList [$wi.if$iface_id.ipv6.addr get]]
+    foreach addr $addrs6 {
+	if { [checkIPv6Net $addr] == 0 } {
 	    return
 	}
     }
 
     set oldipaddrs [_getIfcIPv6addrs $node_cfg $iface_id]
-    if { $force || $ipaddrs != $oldipaddrs } {
+    if { $force || $addrs6 != $oldipaddrs } {
 	if { $apply == 1 } {
-	    set node_cfg [_setIfcIPv6addrs $node_cfg $iface_id $ipaddrs]
+	    set node_cfg [_setIfcIPv6addrs $node_cfg $iface_id $addrs6]
 	}
 	set changed 1
 
@@ -2687,7 +2687,7 @@ proc configGUI_ifcIPv6AddressApply { wi node_id iface_id } {
 	    set node_existing_ipv6 [removeFromList $node_existing_ipv6 $oldipaddrs]
 	}
 
-	lappend node_existing_ipv6 {*}$ipaddrs
+	lappend node_existing_ipv6 {*}$addrs6
     }
 }
 
@@ -3561,9 +3561,9 @@ proc createNewConfiguration { wi node_id } {
 proc formatIPaddrList { addrList } {
     set newList {}
     foreach addr [split $addrList ";"] {
-	set ipaddr [string trim $addr]
-	if { $ipaddr != "" } {
-	    lappend newList $ipaddr
+	set addr [string trim $addr]
+	if { $addr != "" } {
+	    lappend newList $addr
 	}
     }
 

--- a/gui/nodecfgGUI.tcl
+++ b/gui/nodecfgGUI.tcl
@@ -1624,7 +1624,7 @@ proc configGUI_ifcIPv4Address { wi node_id iface_id } {
 
     set addrs4 [string trim $addrs4 "; "]
     $wi.if$iface_id.ipv4.addr insert 0 $addrs4
-    $wi.if$iface_id.ipv4.addr configure -validatecommand { checkIPv4Nets %P }
+    $wi.if$iface_id.ipv4.addr configure -validatecommand { checkIPv4NetsDHCP %P }
 
     pack $wi.if$iface_id.ipv4.txt $wi.if$iface_id.ipv4.addr -side left
     pack $wi.if$iface_id.ipv4 -anchor w -padx 10
@@ -2630,9 +2630,13 @@ proc configGUI_ifcIPv4AddressApply { wi node_id iface_id } {
     global changed force apply node_cfg
 
     set addrs4 [formatIPaddrList [$wi.if$iface_id.ipv4.addr get]]
-    foreach addr $addrs4 {
-	if { [checkIPv4Net $addr] == 0 } {
-	    return
+    if { $addrs4 == "dhcp" } {
+	set changed 1
+    } else {
+	foreach addr $addrs4 {
+	    if { [checkIPv4Net $addr] == 0 } {
+		return
+	    }
 	}
     }
 

--- a/runtime/freebsd.tcl
+++ b/runtime/freebsd.tcl
@@ -2371,6 +2371,10 @@ proc getNatIfcCmd { iface_name } {
 }
 
 proc getIPv4IfcCmd { ifc addr primary } {
+    if { $addr == "dhcp" } {
+	return "dhclient -b $ifc"
+    }
+
     if { $primary } {
 	return "ifconfig $ifc inet $addr"
     }
@@ -2378,6 +2382,10 @@ proc getIPv4IfcCmd { ifc addr primary } {
 }
 
 proc getDelIPv4IfcCmd { ifc addr } {
+    if { $addr == "dhcp" } {
+	return "pkill -f 'dhclient.*$ifc\\>'"
+    }
+
     return "ifconfig $ifc inet $addr -alias"
 }
 

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -1630,6 +1630,10 @@ proc getFlushIPv6IfcCmd { iface_name } {
 }
 
 proc getIPv4IfcCmd { ifc addr primary } {
+    if { $addr == "dhcp" } {
+	return "dhclient -nw $ifc"
+    }
+
     return "ip addr add $addr dev $ifc"
 }
 
@@ -1638,6 +1642,10 @@ proc getIPv6IfcCmd { iface_name addr primary } {
 }
 
 proc getDelIPv4IfcCmd { ifc addr } {
+    if { $addr == "dhcp" } {
+	return "pkill -f 'dhclient -nw $ifc\\>'"
+    }
+
     return "ip addr del $addr dev $ifc"
 }
 


### PR DESCRIPTION
Add a way to use `dhclient` as a way of getting an IPv4 address on `NETWORK` nodes (except ext/extnat).

This is done by configuring the IPv4 address of an interface to `dhcp`. When configuring interfaces, IMUNES will run `dhclient $iface_name` in the background. When unconfiguring interfaces, this process will be killed by running `pkill -f 'dhclient.*$iface_name\>'`.

Works both on FreeBSD and Linux if virtualized nodes have `dhclient` installed.

NOTE: even if `dhclient` is killed, the IP address will be assigned to the interface until lease time expires (Linux), but FreeBSD will keep it until `dhclient` is restarted.

Additionally, rename some variables to differentiate between IPv4 and IPv6 addresses.