### PR TITLE
Feature/node type selection

### DIFF
--- a/config/nodecfg.tcl
+++ b/config/nodecfg.tcl
@@ -1493,10 +1493,23 @@ proc routerRoutesUncfggen { node_id } {
 # INPUTS
 #   * module -- module to add
 #****
-proc registerModule { module } {
+proc registerModule { module { supported_os "linux freebsd" } } {
     global all_modules_list
+    global isOSfreebsd isOSlinux runnable_node_types
 
-    lappend all_modules_list $module
+    if { $module ni $all_modules_list } {
+	lappend all_modules_list $module
+    }
+
+    if { $isOSfreebsd } {
+	if { "freebsd" in $supported_os && $module ni $runnable_node_types } {
+	    lappend runnable_node_types $module
+	}
+    } elseif { $isOSlinux } {
+	if { "linux" in $supported_os && $module ni $runnable_node_types } {
+	    lappend runnable_node_types $module
+	}
+    }
 }
 
 #****f* nodecfg.tcl/deregisterModule

--- a/gui/debug.tcl
+++ b/gui/debug.tcl
@@ -171,5 +171,9 @@ bind . <F6> {
     source "$ROOTDIR/$LIBDIR/gui/debug.tcl"
 
     applyOptions
+
+    redrawAll
+    refreshToolBarNodes
+
     dputs "Reloaded all sources."
 }

--- a/gui/debug.tcl
+++ b/gui/debug.tcl
@@ -119,6 +119,7 @@ bind . <F6> {
     global isOSfreebsd
 
     set all_modules_list {}
+    set runnable_node_types {}
 
     source "$ROOTDIR/$LIBDIR/runtime/cfgparse.tcl"
     source "$ROOTDIR/$LIBDIR/runtime/common.tcl"

--- a/gui/drawing.tcl
+++ b/gui/drawing.tcl
@@ -1,3 +1,38 @@
+proc refreshToolBarNodes {} {
+    global mf all_modules_list runnable_node_types
+
+    catch { destroy $mf.left.link_nodes }
+    catch { destroy $mf.left.net_nodes }
+
+    menu $mf.left.link_nodes -title "Link layer nodes"
+    menu $mf.left.net_nodes -title "Network layer nodes"
+
+    foreach node_type $all_modules_list {
+	set image [image create photo -file [$node_type.icon toolbar]]
+
+	if { [$node_type.netlayer] == "LINK" } {
+	    set frame_element "$mf.left.link_nodes"
+	} elseif { [$node_type.netlayer] == "NETWORK" } {
+	    set frame_element "$mf.left.net_nodes"
+	}
+
+	set background_color ""
+	if { $node_type ni $runnable_node_types } {
+	    global show_unsupported_nodes
+
+	    if { ! $show_unsupported_nodes } {
+		continue
+	    }
+
+	    set background_color "-background \"#bc5555\" -activebackground \"#bc5555\""
+	}
+
+	$frame_element add command -image $image -hidemargin 1 \
+	    -compound left -label [string range [$node_type.toolbarIconDescr] 8 end] \
+	    -command "setActiveTool $node_type" {*}$background_color
+    }
+}
+
 #****f* editor.tcl/redrawAll
 # NAME
 #   redrawAll -- redraw all

--- a/gui/drawing.tcl
+++ b/gui/drawing.tcl
@@ -149,13 +149,14 @@ proc redrawAll {} {
 #   * node_id -- node id
 #****
 proc drawNode { node_id } {
-    global show_node_labels pseudo
+    global show_node_labels pseudo runnable_node_types
 
     set type [getNodeType $node_id]
     set zoom [getFromRunning "zoom"]
     lassign [lmap coord [getNodeCoords $node_id] {expr $coord * $zoom}] x y
 
     .panwin.f1.c delete -withtags "node && $node_id"
+    .panwin.f1.c delete -withtags "nodedisabled && $node_id"
     .panwin.f1.c delete -withtags "nodelabel && $node_id"
 
     set custom_icon [getCustomIcon $node_id]
@@ -163,6 +164,7 @@ proc drawNode { node_id } {
 	global $type
 
 	.panwin.f1.c create image $x $y -image [set $type] -tags "node $node_id"
+	set image_h [image height [set $type]]
     } else {
 	global icon_size
 
@@ -179,10 +181,19 @@ proc drawNode { node_id } {
 		.panwin.f1.c create image $x $y -image [set img_$custom_icon] -tags "node $node_id"
 	    }
 	}
+
+	set image_h [image height img_$custom_icon]
     }
 
-    lassign [lmap coord [getNodeLabelCoords $node_id] {expr int($coord * $zoom)}] x y
     if { $type != "pseudo" } {
+	if { $type ni $runnable_node_types } {
+	    global defaultFontSize
+
+	    .panwin.f1.c create text $x [expr $y - int($image_h/2) - 1.3*$defaultFontSize] \
+		-fill "#ff0c0c" -text "DISABLED" -tags "nodedisabled $node_id" -justify center \
+		-font "imnDisabledFont" -state disabled
+	}
+
 	set label_str [getNodeName $node_id]
 
 	set has_empty_ifaces 0
@@ -221,6 +232,7 @@ proc drawNode { node_id } {
 	set color blue
     }
 
+    lassign [lmap coord [getNodeLabelCoords $node_id] {expr int($coord * $zoom)}] x y
     set label_elem [.panwin.f1.c create text $x $y -fill $color \
 	-text "$label_str" -tags "nodelabel $node_id" -justify center]
 

--- a/gui/initgui.tcl
+++ b/gui/initgui.tcl
@@ -218,7 +218,6 @@ menu .menubar
 .menubar add cascade -label Experiment -underline 1 -menu .menubar.experiment
 .menubar add cascade -label Help -underline 0 -menu .menubar.help
 
-
 #
 # File
 #
@@ -725,6 +724,12 @@ menu $m -tearoff 0
 
 .menubar.view add separator
 
+.menubar.view add checkbutton -label "Show Unsupported Nodes" \
+    -variable show_unsupported_nodes -underline 5 \
+    -command { refreshToolBarNodes }
+
+.menubar.view add separator
+
 .menubar.view add checkbutton -label "Show Background Image" \
     -underline 5 -variable show_background_image \
     -command { redrawAll }
@@ -961,22 +966,7 @@ foreach b {select link} {
     bind $mf.left.$b <Any-Leave> ".bottom.textbox config -text {}"
 }
 
-menu $mf.left.link_nodes -title "Link layer nodes"
-menu $mf.left.net_nodes -title "Network layer nodes"
-foreach b $all_modules_list {
-    set image [image create photo -file [$b.icon toolbar]]
-
-    if { [$b.netlayer] == "LINK" } {
-	$mf.left.link_nodes add command -image $image -hidemargin 1 \
-	    -compound left -label [string range [$b.toolbarIconDescr] 8 end] \
-	    -command "setActiveTool $b"
-    } elseif { [$b.netlayer] == "NETWORK" } {
-	$mf.left.net_nodes add command -image $image -hidemargin 1 \
-	    -compound left -label [string range [$b.toolbarIconDescr] 8 end] \
-	    -command "setActiveTool $b"
-    }
-}
-
+refreshToolBarNodes
 set image [image create photo -file $ROOTDIR/$LIBDIR/icons/tiny/l2.gif]
 ttk::menubutton $mf.left.link_layer -image $image -style Toolbutton \
     -menu $mf.left.link_nodes -direction right

--- a/gui/mouse.tcl
+++ b/gui/mouse.tcl
@@ -1595,7 +1595,7 @@ proc button1-motion { c x y } {
 
 	    set node_id [lindex [$c gettags $img] 1]
 
-	    foreach elem { "selectmark" "nodelabel" "link" } {
+	    foreach elem "selectmark nodedisabled nodelabel link" {
 		set obj [$c find withtag "$elem && $node_id"]
 		$c move $obj [expr {$x - $lastX}] [expr {$y - $lastY}]
 

--- a/gui/theme.tcl
+++ b/gui/theme.tcl
@@ -38,6 +38,9 @@ ttk::style theme create imunes -parent clam
 font create imnDefaultFont -family TkDefaultFont -size $defaultFontSize
 option add *font imnDefaultFont
 
+font create imnDisabledFont -family TkDefaultFont \
+    -size [expr int(1.3*$defaultFontSize)] -weight bold
+
 namespace eval ttk::theme::imunes {
     variable colors
     array set colors {

--- a/imunes.tcl
+++ b/imunes.tcl
@@ -198,6 +198,7 @@ if { $isOSlinux } {
     set supp_router_models "frr quagga static"
     safeSourceFile $ROOTDIR/$LIBDIR/runtime/linux.tcl
 }
+set runnable_node_types $node_types
 
 if { $isOSfreebsd } {
     safeSourceFile $ROOTDIR/$LIBDIR/runtime/freebsd.tcl

--- a/imunes.tcl
+++ b/imunes.tcl
@@ -187,6 +187,9 @@ foreach {option default_value} [concat $option_defaults $gui_option_defaults] {
     set $option $default_value
 }
 
+set all_modules_list {}
+set runnable_node_types {}
+
 # Set default node type list
 set node_types "lanswitch hub rj45 stpswitch filter packgen router host pc nat64 ext extnat"
 # Set default supported router models
@@ -194,11 +197,9 @@ set supp_router_models "frr quagga static"
 
 if { $isOSlinux } {
     # Limit default nodes on linux
-    set node_types "lanswitch hub rj45 router pc host nat64 ext extnat"
     set supp_router_models "frr quagga static"
     safeSourceFile $ROOTDIR/$LIBDIR/runtime/linux.tcl
 }
-set runnable_node_types $node_types
 
 if { $isOSfreebsd } {
     safeSourceFile $ROOTDIR/$LIBDIR/runtime/freebsd.tcl

--- a/nodes/filter.tcl
+++ b/nodes/filter.tcl
@@ -38,7 +38,7 @@
 #****
 
 set MODULE filter
-registerModule $MODULE
+registerModule $MODULE "freebsd"
 
 ################################################################################
 ########################### CONFIGURATION PROCEDURES ###########################

--- a/nodes/packgen.tcl
+++ b/nodes/packgen.tcl
@@ -38,7 +38,7 @@
 #****
 
 set MODULE packgen
-registerModule $MODULE
+registerModule $MODULE "freebsd"
 
 ################################################################################
 ########################### CONFIGURATION PROCEDURES ###########################

--- a/nodes/stpswitch.tcl
+++ b/nodes/stpswitch.tcl
@@ -38,7 +38,7 @@
 #****
 
 set MODULE stpswitch
-registerModule $MODULE
+registerModule $MODULE "freebsd"
 
 ################################################################################
 ########################### CONFIGURATION PROCEDURES ###########################

--- a/nodes/wlan.tcl
+++ b/nodes/wlan.tcl
@@ -25,7 +25,7 @@
 
 set MODULE wlan
 
-registerModule $MODULE
+registerModule $MODULE "freebsd"
 
 proc $MODULE.prepareSystem {} {
     catch { exec kldload ng_rfee }

--- a/runtime/execute.tcl
+++ b/runtime/execute.tcl
@@ -417,6 +417,7 @@ proc nodeIpsecInit { node_id } {
 #****
 proc deployCfg { { execute 0 } } {
     global progressbarCount execMode skip_nodes err_skip_nodesifaces err_skip_nodes
+    global runnable_node_types
 
     if { ! $execute } {
 	if { ! [getFromRunning "cfg_deployed"] } {
@@ -468,6 +469,20 @@ proc deployCfg { { execute 0 } } {
     foreach node_id $instantiate_nodes {
 	set node_type [getNodeType $node_id]
 	if { $node_type != "pseudo" } {
+	    if { $node_type ni $runnable_node_types } {
+		set instantiate_nodes [removeFromList $instantiate_nodes $node_id]
+		set configure_nodes [removeFromList $configure_nodes $node_id]
+		if { $create_nodes_ifaces != "*" && $node_id in [dict keys $create_nodes_ifaces] } {
+		    dict unset create_nodes_ifaces $node_id
+		}
+
+		if { $configure_nodes_ifaces != "*" && $node_id in [dict keys $configure_nodes_ifaces] } {
+		    dict unset configure_nodes_ifaces $node_id
+		}
+
+		continue
+	    }
+
 	    if { [$node_type.virtlayer] != "VIRTUALIZED" } {
 		lappend native_nodes $node_id
 	    } else {
@@ -699,7 +714,7 @@ proc execute_prepareSystem {} {
 }
 
 proc execute_nodesCreate { nodes nodes_count w } {
-    global progressbarCount execMode skip_nodes
+    global progressbarCount execMode runnable_node_types skip_nodes
 
     set eid [getFromRunning "eid"]
 
@@ -740,7 +755,7 @@ proc waitForInstantiateNodes { nodes nodes_count w } {
     set t_start [clock milliseconds]
 
     set batchStep 0
-    set nodes_left $nodes
+    set nodes_left [removeFromList $nodes $skip_nodes]
     while { [llength $nodes_left] > 0 } {
 	displayBatchProgress $batchStep $nodes_count
 	foreach node_id $nodes_left {


### PR DESCRIPTION
Enable editing and running topologies even with unsupported nodes. For example: on Linux, this enables opening and running topologies with FreeBSD-only nodes without errors. The behavior of unsupported nodes on execute/terminate is similar to regular nodes which end up in error state on their creation, but we don't mark them as erroneous  - we don't set them to 'running' state and links connected to them are also not created. Basically, unsupported nodes are simply skipped/ignored.

Add a toggle in View menu for showing unsupported nodes in the toolbar (default is off).

Add visual cues for unsupported nodes in the toolbar and on the canvas.