### PR TITLE
Refactor/node startup check

### DIFF
--- a/runtime/execute.tcl
+++ b/runtime/execute.tcl
@@ -754,6 +754,8 @@ proc waitForInstantiateNodes { nodes nodes_count w } {
 
     set batchStep 0
     set nodes_left $nodes
+    # ignore first run when checking for timeout
+    set old_nodes_left -1
     while { [llength $nodes_left] > 0 } {
 	displayBatchProgress $batchStep $nodes_count
 	foreach node_id $nodes_left {
@@ -775,8 +777,13 @@ proc waitForInstantiateNodes { nodes nodes_count w } {
 	    displayBatchProgress $batchStep $nodes_count
 
 	    set nodes_left [removeFromList $nodes_left $node_id]
+	}
 
+	if { $old_nodes_left != [llength $nodes_left] } {
+	    set old_nodes_left [llength $nodes_left]
 	    set t_start [clock milliseconds]
+
+	    continue
 	}
 
 	set t_last [clock milliseconds]
@@ -908,6 +915,8 @@ proc waitForInitConf { nodes nodes_count w } {
 
     set batchStep 0
     set nodes_left $nodes
+    # ignore first run when checking for timeout
+    set old_nodes_left -1
     while { [llength $nodes_left] > 0 } {
 	displayBatchProgress $batchStep $nodes_count
 	foreach node_id $nodes_left {
@@ -927,8 +936,13 @@ proc waitForInitConf { nodes nodes_count w } {
 	    displayBatchProgress $batchStep $nodes_count
 
 	    set nodes_left [removeFromList $nodes_left $node_id]
+	}
 
+	if { $old_nodes_left != [llength $nodes_left] } {
+	    set old_nodes_left [llength $nodes_left]
 	    set t_start [clock milliseconds]
+
+	    continue
 	}
 
 	set t_last [clock milliseconds]
@@ -1188,6 +1202,8 @@ proc configureIfacesWait { nodes_ifaces nodes_count w } {
 
     set batchStep 0
     set nodes_left $nodes
+    # ignore first run when checking for timeout
+    set old_nodes_left -1
     while { [llength $nodes_left] > 0 } {
 	displayBatchProgress $batchStep $nodes_count
 	foreach node_id $nodes_left {
@@ -1207,8 +1223,13 @@ proc configureIfacesWait { nodes_ifaces nodes_count w } {
 	    displayBatchProgress $batchStep $nodes_count
 
 	    set nodes_left [removeFromList $nodes_left $node_id]
+	}
 
+	if { $old_nodes_left != [llength $nodes_left] } {
+	    set old_nodes_left [llength $nodes_left]
 	    set t_start [clock milliseconds]
+
+	    continue
 	}
 
 	set t_last [clock milliseconds]
@@ -1330,6 +1351,8 @@ proc waitForConfStart { nodes nodes_count w } {
 
     set batchStep 0
     set nodes_left $nodes
+    # ignore first run when checking for timeout
+    set old_nodes_left -1
     while { [llength $nodes_left] > 0 } {
 	displayBatchProgress $batchStep $nodes_count
 	foreach node_id $nodes_left {
@@ -1349,8 +1372,13 @@ proc waitForConfStart { nodes nodes_count w } {
 	    displayBatchProgress $batchStep $nodes_count
 
 	    set nodes_left [removeFromList $nodes_left $node_id]
+	}
 
+	if { $old_nodes_left != [llength $nodes_left] } {
+	    set old_nodes_left [llength $nodes_left]
 	    set t_start [clock milliseconds]
+
+	    continue
 	}
 
 	set t_last [clock milliseconds]

--- a/runtime/execute.tcl
+++ b/runtime/execute.tcl
@@ -781,7 +781,7 @@ proc waitForInstantiateNodes { nodes nodes_count w } {
 
 	set t_last [clock milliseconds]
 	if { [llength $nodes_left] > 0 && [expr {($t_last - $t_start)/1000.0}] > $nodecreate_timeout } {
-	    set skip_nodes $nodes_left
+	    lappend skip_nodes {*}$nodes_left
 	    break
 	}
     }
@@ -933,7 +933,7 @@ proc waitForInitConf { nodes nodes_count w } {
 
 	set t_last [clock milliseconds]
 	if { [llength $nodes_left] > 0 && [expr {($t_last - $t_start)/1000.0}] > $nodecreate_timeout } {
-	    set skip_nodes $nodes_left
+	    lappend skip_nodes {*}$nodes_left
 	    break
 	}
     }

--- a/runtime/freebsd.tcl
+++ b/runtime/freebsd.tcl
@@ -1293,7 +1293,7 @@ proc isNodeStarted { node_id } {
     set jail_id "[getFromRunning "eid"].$node_id"
 
     try {
-	exec jls -j $jail_id
+	exec timeout 0.1 jls -j $jail_id
     } on error {} {
 	return false
     }
@@ -1480,7 +1480,7 @@ proc isNodeInitNet { node_id } {
     set jail_id "[getFromRunning "eid"].$node_id"
 
     try {
-       exec jexec $jail_id rm /tmp/init > /dev/null
+       exec timeout 0.1 jexec $jail_id rm /tmp/init > /dev/null
     } on error {} {
        return false
     }
@@ -1611,7 +1611,7 @@ proc isNodeIfacesConfigured { node_id } {
     }
 
     try {
-	exec jexec $jail_id test -f /out_ifaces.log > /dev/null
+	exec timeout 0.1 jexec $jail_id test -f /out_ifaces.log > /dev/null
     } on error {} {
 	return false
     }
@@ -1633,7 +1633,7 @@ proc isNodeConfigured { node_id } {
     }
 
     try {
-	exec jexec $jail_id test -f /out.log > /dev/null
+	exec timeout 0.1 jexec $jail_id test -f /out.log > /dev/null
     } on error {} {
 	return false
     }

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -795,7 +795,7 @@ proc configureICMPoptions { node_id } {
 }
 
 proc isNodeInitNet { node_id } {
-    global skip_nodes
+    global skip_nodes nodecreate_timeout
 
     if { $node_id in $skip_nodes } {
 	return true
@@ -804,13 +804,7 @@ proc isNodeInitNet { node_id } {
     set docker_id "[getFromRunning "eid"].$node_id"
 
     try {
-	exec timeout 0.1 docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
-    } on ok mergedir {
-	try {
-	    exec test -f ${mergedir}/tmp/init
-	} on error {} {
-	    return false
-	}
+	exec timeout [expr $nodecreate_timeout/5.0] docker exec $docker_id rm /tmp/init >/dev/null
     } on error {} {
 	return false
     }
@@ -1150,21 +1144,12 @@ proc isNodeIfacesConfigured { node_id } {
     }
 
     try {
-	# docker exec sometimes hangs, so don't use it while we have other pipes opened
-	exec timeout 0.1 docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
-    } on ok mergedir {
-	catch { exec test ! -f ${mergedir}/tout_ifaces.log } err1
-	catch { exec test -f ${mergedir}/out_ifaces.log } err2
-	if { $err1 == "" && $err2 == "" } {
-	    return true
-	}
-
+	exec timeout 0.1 docker exec -t $docker_id sh -c "test ! -f /tout_ifaces.log && test -f /out_ifaces.log"
+    } on error {} {
 	return false
-    } on error err {
-	dputs stderr "Error on docker inspect: '$err'"
     }
 
-    return false
+    return true
 }
 
 proc isNodeConfigured { node_id } {
@@ -1181,21 +1166,12 @@ proc isNodeConfigured { node_id } {
     }
 
     try {
-	# docker exec sometimes hangs, so don't use it while we have other pipes opened
-	exec timeout 0.1 docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
-    } on ok mergedir {
-	catch { exec test ! -f ${mergedir}/tout.log } err1
-	catch { exec test -f ${mergedir}/out.log } err2
-	if { $err1 == "" && $err2 == "" } {
-	    return true
-	}
-
+	exec timeout 0.1 docker exec -t $docker_id sh -c "test ! -f /tout.log && test -f /out.log"
+    } on error {} {
 	return false
-    } on error err {
-	dputs stderr "Error on docker inspect: '$err'"
     }
 
-    return false
+    return true
 }
 
 proc isNodeError { node_id } {
@@ -1212,24 +1188,16 @@ proc isNodeError { node_id } {
     set docker_id "[getFromRunning "eid"].$node_id"
 
     try {
-	# docker exec sometimes hangs, so don't use it while we have other pipes opened
-	exec docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
-    } on ok mergedir {
-	if { ! [file exists ${mergedir}/err.log] } {
-	    return ""
-	}
-
-	catch { exec sed "/^+ /d" ${mergedir}/err.log } errlog
+	exec timeout 0.1 docker exec -t $docker_id sed "/^+ /d" /err.log
+    } on error {} {
+	return ""
+    } on ok errlog {
 	if { $errlog == "" } {
 	    return false
 	}
 
 	return true
-    } on error err {
-	puts stderr "Error on docker inspect: '$err'"
     }
-
-    return true
 }
 
 proc isNodeErrorIfaces { node_id } {
@@ -1246,24 +1214,16 @@ proc isNodeErrorIfaces { node_id } {
     set docker_id "[getFromRunning "eid"].$node_id"
 
     try {
-	# docker exec sometimes hangs, so don't use it while we have other pipes opened
-	exec docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
-    } on ok mergedir {
-	if { ! [file exists ${mergedir}/err_ifaces.log] } {
-	    return ""
-	}
-
-	catch { exec sed "/^+ /d" ${mergedir}/err_ifaces.log } errlog
+	exec timeout 0.1 docker exec -t $docker_id sed "/^+ /d" /err_ifaces.log
+    } on error {} {
+	return ""
+    } on ok errlog {
 	if { $errlog == "" } {
 	    return false
 	}
 
 	return true
-    } on error err {
-	puts stderr "Error on docker inspect: '$err'"
     }
-
-    return true
 }
 
 proc removeNetns { netns } {

--- a/runtime/linux.tcl
+++ b/runtime/linux.tcl
@@ -593,7 +593,7 @@ proc isNodeStarted { node_id } {
 
     set docker_id "[getFromRunning "eid"].$node_id"
 
-    catch { exec docker inspect --format '{{.State.Running}}' $docker_id } status
+    catch { exec timeout 0.1 docker inspect --format '{{.State.Running}}' $docker_id } status
 
     return [string match 'true' $status]
 }
@@ -804,7 +804,7 @@ proc isNodeInitNet { node_id } {
     set docker_id "[getFromRunning "eid"].$node_id"
 
     try {
-	exec docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
+	exec timeout 0.1 docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
     } on ok mergedir {
 	try {
 	    exec test -f ${mergedir}/tmp/init
@@ -1151,7 +1151,7 @@ proc isNodeIfacesConfigured { node_id } {
 
     try {
 	# docker exec sometimes hangs, so don't use it while we have other pipes opened
-	exec docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
+	exec timeout 0.1 docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
     } on ok mergedir {
 	catch { exec test ! -f ${mergedir}/tout_ifaces.log } err1
 	catch { exec test -f ${mergedir}/out_ifaces.log } err2
@@ -1161,7 +1161,7 @@ proc isNodeIfacesConfigured { node_id } {
 
 	return false
     } on error err {
-	puts stderr "Error on docker inspect: '$err'"
+	dputs stderr "Error on docker inspect: '$err'"
     }
 
     return false
@@ -1182,7 +1182,7 @@ proc isNodeConfigured { node_id } {
 
     try {
 	# docker exec sometimes hangs, so don't use it while we have other pipes opened
-	exec docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
+	exec timeout 0.1 docker inspect -f "{{.GraphDriver.Data.MergedDir}}" $docker_id
     } on ok mergedir {
 	catch { exec test ! -f ${mergedir}/tout.log } err1
 	catch { exec test -f ${mergedir}/out.log } err2
@@ -1192,7 +1192,7 @@ proc isNodeConfigured { node_id } {
 
 	return false
     } on error err {
-	puts stderr "Error on docker inspect: '$err'"
+	dputs stderr "Error on docker inspect: '$err'"
     }
 
     return false


### PR DESCRIPTION
Refactor the way we check whether nodes are started/configured: don't wait for each `check` command to finish, but use _timeout_ command to terminate it after 0.1 seconds and check the next node.

If there are no changes in `timeout` seconds, skip unfinished nodes in further execution. There are 3 configurable timeouts in imunes.tcl  - for node startup, interface configuration and node configuration (these will be configurable soon).