### PR TITLE
Fix/exec and term node handling

### DIFF
--- a/gui/editor.tcl
+++ b/gui/editor.tcl
@@ -1186,7 +1186,6 @@ proc toggleAutoExecutionGUI { { new_value "" } } {
 	    }
 
 	    .menubar.experiment entryconfigure $index -label "Resume execution"
-	    setToExecuteVars "terminate_cfg" [cfgGet]
 	    if { [getFromRunning "cfg_deployed"] } {
 		.bottom.oper_mode configure -text "paused"
 		.bottom.oper_mode configure -foreground "red"

--- a/gui/initgui.tcl
+++ b/gui/initgui.tcl
@@ -867,10 +867,14 @@ menu .menubar.experiment -tearoff 0
 .menubar.experiment add command -label "Pause execution" -underline 0 \
 	-command {
 	    set auto_execution [getFromRunning "auto_execution"]
+
 	    setToRunning "auto_execution" [expr $auto_execution ^ 1]
 	    if { [getFromRunning "cfg_deployed"] && ! $auto_execution } {
+		# when going from non-auto to auto execution, trigger (un)deployCfg
 		undeployCfg
 		deployCfg
+	    } else {
+		setToExecuteVars "terminate_cfg" [cfgGet]
 	    }
 
 	    toggleAutoExecutionGUI

--- a/runtime/common.tcl
+++ b/runtime/common.tcl
@@ -786,7 +786,6 @@ proc setOperMode { new_oper_mode } {
 
 	    set eid [getFromRunning "eid"]
 	    if { $regular_termination } {
-		setToExecuteVars "terminate_cfg" [cfgGet]
 		setToExecuteVars "terminate_nodes" [getFromRunning "node_list"]
 		setToExecuteVars "destroy_nodes_ifaces" "*"
 		setToExecuteVars "terminate_links" [getFromRunning "link_list"]
@@ -803,6 +802,7 @@ proc setOperMode { new_oper_mode } {
 	    killExtProcess "socat.*$eid"
 	    pipesClose
 
+	    setToExecuteVars "terminate_cfg" [cfgGet]
 	    setToRunning "cfg_deployed" false
 
 	    wm protocol . WM_DELETE_WINDOW {

--- a/runtime/execute.tcl
+++ b/runtime/execute.tcl
@@ -667,7 +667,9 @@ proc deployCfg { { execute 0 } } {
     finishExecuting 1 "" $w
 
     if { ! $execute } {
-	createExperimentFiles $eid
+	if { [getFromRunning "auto_execution"] } {
+	    createExperimentFiles $eid
+	}
     }
     createRunningVarsFile $eid
 
@@ -718,6 +720,7 @@ proc execute_prepareSystem {} {
     prepareDevfs
     createExperimentContainer
     createExperimentFiles $eid
+    createRunningVarsFile $eid
 }
 
 proc execute_nodesCreate { nodes nodes_count w } {

--- a/runtime/terminate.tcl
+++ b/runtime/terminate.tcl
@@ -234,6 +234,11 @@ proc undeployCfg { { eid "" } { terminate 0 } } {
 
 	    return
 	}
+    } else {
+	if { $terminate_cfg != "" && $terminate_cfg != [cfgGet] } {
+	    setToExecuteVars "terminate_nodes" [dict keys [_cfgGet $terminate_cfg "nodes"]]
+	    setToExecuteVars "terminate_links" [dict keys [_cfgGet $terminate_cfg "links"]]
+	}
     }
 
     foreach var "terminate_nodes destroy_nodes_ifaces terminate_links

--- a/scripts/himage
+++ b/scripts/himage
@@ -67,10 +67,16 @@ get_explist() {
 	if test -r /var/run/imunes/$exp/; then
 	    if test $1 = "nodes"; then
 		nodes=`jq -r '.nodes' /var/run/imunes/$exp/config.imn`
+		non_running=`grep -Eo 'n[0-9]+_running false' /var/run/imunes/$exp/runningVars | cut -d'_' -f1 | jq -R . | jq -s .`
 		if test "$nodes" = "null"; then
 		    data=""
 		else
-		    data=`jq -r '.nodes | to_entries | map(.value.name + if .value.type == "rj45" then " (" + (.value.ifaces | to_entries | map(.value.name) | join(", ")) + ")" else "" end) | join(", ")' /var/run/imunes/$exp/config.imn`
+		    data=`jq --argjson nonRunning "$non_running" -r '.nodes | to_entries | map(
+			.key as $id |
+			.value.name +
+			(if $nonRunning | index($id) then "*" else "" end) +
+			(if .value == "rj45" then " (" + (.value.ifaces | to_entries | map(.value.name) | join(", ")) + ")" else "" end)
+		    ) | join(", ")' /var/run/imunes/$exp/config.imn`
 		fi
 	    else
 		if test -r /var/run/imunes/$exp/name; then

--- a/scripts/himage.linux
+++ b/scripts/himage.linux
@@ -71,11 +71,17 @@ get_explist() {
 
 	if test $1 = "nodes"; then
 	    nodes=`jq -r '.nodes' /var/run/imunes/$exp/config.imn`
-		if test "$nodes" = "null"; then
-			data=""
-		else
-			data=`jq -r '.nodes | to_entries | map(.value.name + if .value.type == "rj45" then " (" + (.value.ifaces | to_entries | map(.value.name) | join(", ")) + ")" else "" end) | join(", ")' /var/run/imunes/$exp/config.imn`
-		fi
+	    non_running=`grep -Eo 'n[0-9]+_running false' /var/run/imunes/$exp/runningVars | cut -d'_' -f1 | jq -R . | jq -s .`
+	    if test "$nodes" = "null"; then
+		data=""
+	    else
+		data=`jq --argjson nonRunning "$non_running" -r '.nodes | to_entries | map(
+		    .key as $id |
+		    .value.name +
+		    (if $nonRunning | index($id) then "*" else "" end) +
+		    (if .value == "rj45" then " (" + (.value.ifaces | to_entries | map(.value.name) | join(", ")) + ")" else "" end)
+		) | join(", ")' /var/run/imunes/$exp/config.imn`
+	    fi
 	else
 	    if test -r /var/run/imunes/$exp/name; then
 		exp_name=`cat /var/run/imunes/$exp/name`


### PR DESCRIPTION
Fix execute/terminate handling of experiment files and
running/non-running nodes. Update himage to show non-running nodes with
a * character next to the node name.